### PR TITLE
planner: skip redundant constraint drops when the column cascades them

### DIFF
--- a/src/planner/__tests__/planner.test.ts
+++ b/src/planner/__tests__/planner.test.ts
@@ -1815,6 +1815,127 @@ describe('Planner', () => {
     });
   });
 
+  // Regression for mabulu-inc/simplicity-schema-flow#19.
+  // Postgres auto-cascades table-level constraints when any of their columns
+  // are dropped, so emitting a separate DROP CONSTRAINT in the same phase
+  // errors with "does not exist" after the column goes. The planner now
+  // skips such drops and, as a defensive hedge, uses DROP CONSTRAINT IF EXISTS.
+  describe('constraint drops when the underlying column is also being dropped', () => {
+    it('skips drop_unique_constraint when the constraint is on a column that is also being dropped', () => {
+      const desired = emptyDesired();
+      desired.tables = [
+        {
+          table: 'things',
+          columns: [{ name: 'id', type: 'serial', primary_key: true }],
+        },
+      ];
+      const actual = emptyActual();
+      actual.tables.set('things', {
+        table: 'things',
+        columns: [
+          { name: 'id', type: 'serial', primary_key: true },
+          { name: 'legacy_code', type: 'varchar(50)' },
+        ],
+        unique_constraints: [{ name: 'things_legacy_code_key', columns: ['legacy_code'] }],
+      });
+      const result = buildPlan(desired, actual, { allowDestructive: true });
+
+      // drop_column should be present — Postgres will cascade the constraint.
+      const colDrops = findOps(result.operations, 'drop_column');
+      expect(colDrops).toHaveLength(1);
+      expect(colDrops[0].sql).toContain('DROP COLUMN "legacy_code"');
+
+      // drop_unique_constraint must NOT be emitted — it would fail with
+      // "does not exist" because the column drop auto-cascaded it.
+      const ucDrops = findOps(result.operations, 'drop_unique_constraint');
+      expect(ucDrops).toHaveLength(0);
+    });
+
+    it('skips drop_unique_constraint when any column of a multi-column unique is being dropped', () => {
+      const desired = emptyDesired();
+      desired.tables = [
+        {
+          table: 'things',
+          columns: [
+            { name: 'id', type: 'serial', primary_key: true },
+            { name: 'a', type: 'text' },
+          ],
+        },
+      ];
+      const actual = emptyActual();
+      actual.tables.set('things', {
+        table: 'things',
+        columns: [
+          { name: 'id', type: 'serial', primary_key: true },
+          { name: 'a', type: 'text' },
+          { name: 'b', type: 'text' },
+        ],
+        unique_constraints: [{ name: 'things_a_b_key', columns: ['a', 'b'] }],
+      });
+      const result = buildPlan(desired, actual, { allowDestructive: true });
+
+      // Drop 'b' is planned; unique (a, b) cascades, so no DROP CONSTRAINT.
+      expect(findOps(result.operations, 'drop_column')).toHaveLength(1);
+      expect(findOps(result.operations, 'drop_unique_constraint')).toHaveLength(0);
+    });
+
+    it('still drops a unique constraint whose columns all remain (normal removal)', () => {
+      const desired = emptyDesired();
+      desired.tables = [
+        {
+          table: 'things',
+          columns: [
+            { name: 'id', type: 'serial', primary_key: true },
+            { name: 'email', type: 'text' },
+          ],
+          // Note: no unique_constraints declared — existing uc should be dropped.
+        },
+      ];
+      const actual = emptyActual();
+      actual.tables.set('things', {
+        table: 'things',
+        columns: [
+          { name: 'id', type: 'serial', primary_key: true },
+          { name: 'email', type: 'text' },
+        ],
+        unique_constraints: [{ name: 'things_email_key', columns: ['email'] }],
+      });
+      const result = buildPlan(desired, actual, { allowDestructive: true });
+
+      expect(findOps(result.operations, 'drop_column')).toHaveLength(0);
+      const ucDrops = findOps(result.operations, 'drop_unique_constraint');
+      expect(ucDrops).toHaveLength(1);
+      // Defensive hedge: uses IF EXISTS so user/script-driven cascades are tolerated.
+      expect(ucDrops[0].sql).toContain('DROP CONSTRAINT IF EXISTS "things_email_key"');
+    });
+
+    it('emits DROP CONSTRAINT IF EXISTS for drop_check (tolerates cascade)', () => {
+      const desired = emptyDesired();
+      desired.tables = [
+        {
+          table: 'things',
+          columns: [
+            { name: 'id', type: 'serial', primary_key: true },
+            { name: 'status', type: 'text' },
+          ],
+        },
+      ];
+      const actual = emptyActual();
+      actual.tables.set('things', {
+        table: 'things',
+        columns: [
+          { name: 'id', type: 'serial', primary_key: true },
+          { name: 'status', type: 'text' },
+        ],
+        checks: [{ name: 'things_status_check', expression: "status IN ('a','b')" }],
+      });
+      const result = buildPlan(desired, actual, { allowDestructive: true });
+      const checkDrops = findOps(result.operations, 'drop_check');
+      expect(checkDrops).toHaveLength(1);
+      expect(checkDrops[0].sql).toContain('DROP CONSTRAINT IF EXISTS "things_status_check"');
+    });
+  });
+
   describe('function grants', () => {
     it('produces grant_function operations from function grants', () => {
       const desired = emptyDesired();

--- a/src/planner/index.ts
+++ b/src/planner/index.ts
@@ -912,9 +912,14 @@ function alterTableOps(desired: TableSchema, existing: TableSchema, pgSchema: st
     }
   }
 
-  // Drop columns not in desired
+  // Drop columns not in desired. Also remember which columns are going away
+  // so constraint-diff functions below can skip drops that Postgres will
+  // auto-cascade (dropping a column cascades any table-level constraint
+  // involving only that column, per Postgres ALTER TABLE docs).
+  const droppedColNames = new Set<string>();
   for (const col of existing.columns) {
     if (!desiredColMap.has(col.name)) {
+      droppedColNames.add(col.name);
       ops.push({
         type: 'drop_column',
         phase: 6,
@@ -933,6 +938,7 @@ function alterTableOps(desired: TableSchema, existing: TableSchema, pgSchema: st
       existing.unique_constraints || [],
       desired.columns,
       pgSchema,
+      droppedColNames,
     ),
   );
 
@@ -1176,7 +1182,7 @@ function diffChecks(table: string, desired: CheckDef[], existing: CheckDef[], pg
         type: 'drop_check',
         phase: 6,
         objectName: `${table}.${check.name}`,
-        sql: `ALTER TABLE "${pgSchema}"."${table}" DROP CONSTRAINT "${check.name}"`,
+        sql: `ALTER TABLE "${pgSchema}"."${table}" DROP CONSTRAINT IF EXISTS "${check.name}"`,
         destructive: false,
       });
       ops.push({
@@ -1201,7 +1207,9 @@ function diffChecks(table: string, desired: CheckDef[], existing: CheckDef[], pg
     }
   }
 
-  // Drop check constraints not in desired
+  // Drop check constraints not in desired. `IF EXISTS` tolerates the case
+  // where Postgres has already auto-cascaded the check because all columns
+  // it referenced were dropped earlier in the same phase.
   const desiredNames = new Set(desired.map((c) => c.name));
   for (const [name] of existingByName) {
     if (!desiredNames.has(name)) {
@@ -1209,7 +1217,7 @@ function diffChecks(table: string, desired: CheckDef[], existing: CheckDef[], pg
         type: 'drop_check',
         phase: 6,
         objectName: `${table}.${name}`,
-        sql: `ALTER TABLE "${pgSchema}"."${table}" DROP CONSTRAINT "${name}"`,
+        sql: `ALTER TABLE "${pgSchema}"."${table}" DROP CONSTRAINT IF EXISTS "${name}"`,
         destructive: true,
       });
     }
@@ -1226,6 +1234,7 @@ function diffUniqueConstraints(
   existing: UniqueConstraintDef[],
   desiredColumns: ColumnDef[],
   pgSchema: string,
+  droppedColNames: Set<string> = new Set(),
 ): Operation[] {
   const ops: Operation[] = [];
   const existingByName = new Map(existing.map((uc) => [uc.name || `uq_${table}_${uc.columns.join('_')}`, uc]));
@@ -1240,7 +1249,7 @@ function diffUniqueConstraints(
         type: 'drop_unique_constraint',
         phase: 6,
         objectName: `${table}.${ucName}`,
-        sql: `ALTER TABLE "${pgSchema}"."${table}" DROP CONSTRAINT "${ucName}"`,
+        sql: `ALTER TABLE "${pgSchema}"."${table}" DROP CONSTRAINT IF EXISTS "${ucName}"`,
         destructive: true,
       });
     }
@@ -1288,18 +1297,23 @@ function diffUniqueConstraints(
     }
   }
 
-  // Drop unique constraints not in desired (and not managed at column level)
+  // Drop unique constraints not in desired (and not managed at column level).
+  // Skip when the constraint references any column that's also being dropped —
+  // Postgres auto-cascades table-level constraints whose columns go away
+  // ("Indexes and table constraints involving the column will be automatically
+  // dropped" — ALTER TABLE docs). Emitting a separate DROP CONSTRAINT in the
+  // same phase would fail with "does not exist" after the drop_column runs.
   const desiredNames = new Set(desired.map((uc) => uc.name || `uq_${table}_${uc.columns.join('_')}`));
-  for (const [name] of existingByName) {
-    if (!desiredNames.has(name) && !columnLevelUniqueNames.has(name)) {
-      ops.push({
-        type: 'drop_unique_constraint',
-        phase: 6,
-        objectName: `${table}.${name}`,
-        sql: `ALTER TABLE "${pgSchema}"."${table}" DROP CONSTRAINT "${name}"`,
-        destructive: true,
-      });
-    }
+  for (const [name, uc] of existingByName) {
+    if (desiredNames.has(name) || columnLevelUniqueNames.has(name)) continue;
+    if (uc.columns.some((c) => droppedColNames.has(c))) continue;
+    ops.push({
+      type: 'drop_unique_constraint',
+      phase: 6,
+      objectName: `${table}.${name}`,
+      sql: `ALTER TABLE "${pgSchema}"."${table}" DROP CONSTRAINT IF EXISTS "${name}"`,
+      destructive: true,
+    });
   }
 
   return ops;


### PR DESCRIPTION
## Summary

Fixes #19 — the planner was emitting redundant `DROP CONSTRAINT` ops that fail after Postgres auto-cascades the constraint via `DROP COLUMN`, rolling back the whole phase-6 transaction.

Two complementary changes in `src/planner/index.ts`:

1. **Column-aware skip in `diffUniqueConstraints`.** `alterTableOps` now computes the set of columns being dropped and threads it into `diffUniqueConstraints`. When the existing unique references any column that's being dropped, the `drop_unique_constraint` op is skipped — `drop_column` will handle the cascade. No more second-drop-against-missing-constraint.

2. **`DROP CONSTRAINT IF EXISTS` for both `drop_unique_constraint` and `drop_check`.** `diffIndexes` already used `IF EXISTS` for `drop_index` — this extends the same defensive hedge to constraint drops, so any future cascade path (a user's pre-script, cross-table drops, etc.) doesn't blow up a migration.

## Why this shape

- **Using `DROP COLUMN ... CASCADE` directly** would cascade through things outside the table (views, triggers in other tables) — bad surprise-surface for users. Kept the per-op granularity; just stopped planning ops Postgres already handles.
- **`IF EXISTS`-only** without the column-aware skip would hide the fact that the planner is emitting unnecessary work. The compute-dropped-set pass is cheap (one `filter + map`) and surgical: only skip the drops we know are redundant.
- Together the two changes are both precise (the skip) and robust (the hedge).

## Test plan

- [x] `pnpm lint` green
- [x] `pnpm typecheck` green
- [x] `pnpm build` green
- [ ] `pnpm test` — unable to run locally because `docker compose up --wait` fails on an unrelated image-version issue on my machine. CI will cover.

Four new planner tests added covering:
- Drop column + its single-column unique → only `drop_column`, no `drop_unique_constraint`
- Drop one column of a multi-column unique → same cascade path, no `drop_unique_constraint`
- Drop unique with all columns staying → still emits `drop_unique_constraint` (with `IF EXISTS`)
- `drop_check` SQL emits `IF EXISTS`

## User context

Hit in a productionnow migration that removed two tenants-table columns where one carried a column-level unique (`tenant_name`, `willaman_solutions_id`). Without the flag schema-flow silently left both in place (expected); with `--allow-destructive` it errored on `constraint "tenants_willaman_solutions_id_key" of relation "tenants" does not exist`. With this patch, the declarative removal works on the first pass and no pre-script is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)