### PR TITLE
grants: diff desired vs existing instead of replaying; normalize mixed blocks

### DIFF
--- a/src/cli/__tests__/report.test.ts
+++ b/src/cli/__tests__/report.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import { reportMigrationResult } from '../report.js';
+import type { Operation } from '../../planner/index.js';
+import type { ExecuteResult } from '../../executor/index.js';
+
+function emptyResult(overrides: Partial<ExecuteResult> = {}): ExecuteResult {
+  return {
+    executed: 0,
+    skippedScripts: 0,
+    preScriptsRun: 0,
+    postScriptsRun: 0,
+    dryRun: false,
+    validated: false,
+    executedOperations: [],
+    ...overrides,
+  };
+}
+
+function capture(): { write: (msg: string) => void; lines: string[] } {
+  const lines: string[] = [];
+  return { write: (m: string) => lines.push(m), lines };
+}
+
+describe('reportMigrationResult', () => {
+  // Regression for mabulu-inc/simplicity-schema-flow#17 Issue 3:
+  // "Seeded: timezones (418 unchanged)" used to log on every run even when
+  // nothing was written. In default mode the line is noise; in verbose we
+  // still show it for debugging.
+  it('suppresses no-op seed ops in default mode', () => {
+    const ops: Operation[] = [
+      {
+        type: 'seed_table',
+        phase: 10,
+        objectName: 'timezones',
+        sql: 'INSERT ...',
+        destructive: false,
+        seedResult: { inserted: 0, updated: 0, unchanged: 418 },
+      },
+    ];
+    const { write, lines } = capture();
+    reportMigrationResult({
+      result: emptyResult({ executed: 1, executedOperations: ops }),
+      operations: ops,
+      mode: 'default',
+      write,
+    });
+    expect(lines.some((l) => l.includes('timezones'))).toBe(false);
+  });
+
+  it('still shows no-op seed ops in verbose mode', () => {
+    const ops: Operation[] = [
+      {
+        type: 'seed_table',
+        phase: 10,
+        objectName: 'timezones',
+        sql: 'INSERT ...',
+        destructive: false,
+        seedResult: { inserted: 0, updated: 0, unchanged: 418 },
+      },
+    ];
+    const { write, lines } = capture();
+    reportMigrationResult({
+      result: emptyResult({ executed: 1, executedOperations: ops }),
+      operations: ops,
+      mode: 'verbose',
+      write,
+    });
+    expect(lines.some((l) => l.includes('timezones') && l.includes('418 unchanged'))).toBe(true);
+  });
+
+  it('logs seed ops that actually wrote rows in default mode', () => {
+    const ops: Operation[] = [
+      {
+        type: 'seed_table',
+        phase: 10,
+        objectName: 'api_types',
+        sql: 'INSERT ...',
+        destructive: false,
+        seedResult: { inserted: 2, updated: 0, unchanged: 1 },
+      },
+    ];
+    const { write, lines } = capture();
+    reportMigrationResult({
+      result: emptyResult({ executed: 1, executedOperations: ops }),
+      operations: ops,
+      mode: 'default',
+      write,
+    });
+    expect(lines.some((l) => l.includes('api_types') && l.includes('2 inserted'))).toBe(true);
+  });
+});

--- a/src/cli/report.ts
+++ b/src/cli/report.ts
@@ -23,9 +23,12 @@ export function reportMigrationResult(options: ReportOptions): void {
     return;
   }
 
-  // Default and verbose: show per-operation change lines
+  // Default and verbose: show per-operation change lines.
+  // In default mode, skip seed ops that wrote nothing — the line would
+  // read "Seeded: X (N unchanged)" which is noise. Still shown in verbose.
   if (mode === 'default' || mode === 'verbose') {
     for (const op of operations) {
+      if (mode === 'default' && isNoOpSeed(op)) continue;
       write(`  ${formatOperationMessage(op)}`);
     }
   }
@@ -43,4 +46,10 @@ export function reportMigrationResult(options: ReportOptions): void {
   if (result.skippedScripts > 0) {
     write(`  Skipped (unchanged): ${result.skippedScripts}`);
   }
+}
+
+function isNoOpSeed(op: Operation): boolean {
+  if (op.type !== 'seed_table') return false;
+  if (!op.seedResult) return false;
+  return op.seedResult.inserted === 0 && op.seedResult.updated === 0;
 }

--- a/src/drift/__tests__/drift.test.ts
+++ b/src/drift/__tests__/drift.test.ts
@@ -1754,6 +1754,48 @@ describe('detectDrift', () => {
     expect(grantDrift).toHaveLength(0);
   });
 
+  // Regression for mabulu-inc/simplicity-schema-flow#17 Issue 1.
+  // A single YAML grant block that mixes DELETE (table-only) with
+  // column-qualified INSERT/SELECT/UPDATE used to trip drift after a
+  // successful apply: Postgres stores the grant as two rows (column_privileges
+  // + table_privileges), drift saw one YAML vs two DB entries, and reported
+  // missing-in-db / missing-in-yaml / different for all three.
+  it('reports no drift when YAML mixes DELETE with column-qualified privileges and DB stores them split', () => {
+    const desired = emptyDesired();
+    desired.tables = [
+      {
+        table: 'user_preferences',
+        columns: [
+          { name: 'user_preference_id', type: 'serial', primary_key: true },
+          { name: 'key', type: 'varchar(100)' },
+        ],
+        grants: [
+          {
+            to: 'app_user',
+            privileges: ['DELETE', 'INSERT', 'SELECT', 'UPDATE'],
+            columns: ['key', 'user_preference_id'],
+          },
+        ],
+      },
+    ];
+    const actual = emptyActual();
+    actual.tables.set('user_preferences', {
+      table: 'user_preferences',
+      columns: [
+        { name: 'user_preference_id', type: 'serial', primary_key: true },
+        { name: 'key', type: 'varchar(100)' },
+      ],
+      grants: [
+        // What Postgres actually stores after applying the mixed block:
+        { to: 'app_user', privileges: ['INSERT', 'SELECT', 'UPDATE'], columns: ['key', 'user_preference_id'] },
+        { to: 'app_user', privileges: ['DELETE'] },
+      ],
+    });
+    const report = detectDrift(desired, actual);
+    const grantDrift = report.items.filter((i) => i.type === 'grant');
+    expect(grantDrift).toHaveLength(0);
+  });
+
   it('detects drift when column-level grant columns differ', () => {
     const desired = emptyDesired();
     desired.tables = [

--- a/src/drift/index.ts
+++ b/src/drift/index.ts
@@ -7,6 +7,7 @@
 
 import type { PoolClient } from 'pg';
 import type { DesiredState, ActualState } from '../planner/index.js';
+import { normalizeGrants } from '../planner/index.js';
 import type {
   TableSchema,
   ColumnDef,
@@ -853,17 +854,26 @@ function driftUniqueConstraints(
 // ─── Grants ─────────────────────────────────────────────────────
 
 function driftGrants(table: string, desired: GrantDef[], actual: GrantDef[]): DriftItem[] {
+  // Normalize both sides first. A single YAML grant block that mixes
+  // column-qualified privileges (SELECT/INSERT/UPDATE/REFERENCES) with
+  // table-only privileges (DELETE/TRUNCATE/TRIGGER) gets stored in two
+  // different Postgres tables (column_privileges + table_privileges); on
+  // read-back we see two grants and mismatched keys unless we split the
+  // YAML side the same way.
+  const nDesired = normalizeGrants(desired);
+  const nActual = normalizeGrants(actual);
+
   const items: DriftItem[] = [];
   const grantKey = (g: GrantDef) => {
     const colsPart = g.columns && g.columns.length > 0 ? `:cols=${[...g.columns].sort().join(',')}` : '';
     return `${g.to}:${[...g.privileges].sort().join(',')}${colsPart}`;
   };
   const actualMap = new Map<string, GrantDef>();
-  for (const g of actual) actualMap.set(grantKey(g), g);
+  for (const g of nActual) actualMap.set(grantKey(g), g);
   const desiredMap = new Map<string, GrantDef>();
-  for (const g of desired) desiredMap.set(grantKey(g), g);
+  for (const g of nDesired) desiredMap.set(grantKey(g), g);
 
-  for (const g of desired) {
+  for (const g of nDesired) {
     const key = grantKey(g);
     const match = actualMap.get(key);
     if (!match) {
@@ -880,7 +890,7 @@ function driftGrants(table: string, desired: GrantDef[], actual: GrantDef[]): Dr
       });
     }
   }
-  for (const g of actual) {
+  for (const g of nActual) {
     if (!desiredMap.has(grantKey(g))) {
       // If the actual grant has columns, check if a table-level desired grant
       // (no columns) covers it — PostgreSQL populates column_privileges for
@@ -890,7 +900,7 @@ function driftGrants(table: string, desired: GrantDef[], actual: GrantDef[]): Dr
       // column-level grant may list fewer privileges than the desired grant.
       if (g.columns && g.columns.length > 0) {
         const actualPrivs = g.privileges;
-        const coveredByTableLevel = desired.some(
+        const coveredByTableLevel = nDesired.some(
           (d) => !d.columns?.length && d.to === g.to && actualPrivs.every((p) => d.privileges.includes(p)),
         );
         if (coveredByTableLevel) continue;

--- a/src/planner/__tests__/planner.test.ts
+++ b/src/planner/__tests__/planner.test.ts
@@ -1040,6 +1040,125 @@ describe('Planner', () => {
       expect(colGrants).toHaveLength(0);
     });
 
+    // Regression for mabulu-inc/simplicity-schema-flow#17 Issue 2.
+    // The planner used to blindly re-emit every declared grant on every run
+    // — the biggest source of noise in no-op migrations. With diff in place
+    // the second run against an unchanged table emits zero grant ops.
+    describe('grant diffing on existing tables', () => {
+      it('emits no grant ops when desired matches existing', () => {
+        const desired = emptyDesired();
+        desired.tables = [
+          {
+            table: 'users',
+            columns: [{ name: 'id', type: 'uuid', primary_key: true }],
+            grants: [{ to: 'app_user', privileges: ['SELECT', 'INSERT'] }],
+          },
+        ];
+        const actual = emptyActual();
+        actual.tables.set('users', {
+          table: 'users',
+          columns: [{ name: 'id', type: 'uuid', primary_key: true }],
+          grants: [{ to: 'app_user', privileges: ['SELECT', 'INSERT'] }],
+        });
+        const result = buildPlan(desired, actual);
+        expect(findOps(result.operations, 'grant_table')).toHaveLength(0);
+        expect(findOps(result.operations, 'grant_column')).toHaveLength(0);
+        expect(findOps(result.operations, 'revoke_table')).toHaveLength(0);
+      });
+
+      it('emits GRANT only for new privileges, not the whole block', () => {
+        const desired = emptyDesired();
+        desired.tables = [
+          {
+            table: 'users',
+            columns: [{ name: 'id', type: 'uuid', primary_key: true }],
+            grants: [{ to: 'app_user', privileges: ['SELECT', 'INSERT', 'UPDATE'] }],
+          },
+        ];
+        const actual = emptyActual();
+        actual.tables.set('users', {
+          table: 'users',
+          columns: [{ name: 'id', type: 'uuid', primary_key: true }],
+          grants: [{ to: 'app_user', privileges: ['SELECT'] }],
+        });
+        const result = buildPlan(desired, actual);
+        const grants = findOps(result.operations, 'grant_table');
+        expect(grants).toHaveLength(1);
+        expect(grants[0].sql).toContain('GRANT INSERT, UPDATE ON');
+        expect(grants[0].sql).not.toContain('SELECT');
+      });
+
+      it('emits REVOKE for privileges present in DB but removed from YAML', () => {
+        const desired = emptyDesired();
+        desired.tables = [
+          {
+            table: 'users',
+            columns: [{ name: 'id', type: 'uuid', primary_key: true }],
+            grants: [{ to: 'app_user', privileges: ['SELECT'] }],
+          },
+        ];
+        const actual = emptyActual();
+        actual.tables.set('users', {
+          table: 'users',
+          columns: [{ name: 'id', type: 'uuid', primary_key: true }],
+          grants: [{ to: 'app_user', privileges: ['SELECT', 'INSERT', 'UPDATE'] }],
+        });
+        const result = buildPlan(desired, actual, { allowDestructive: true });
+        const revokes = findOps(result.operations, 'revoke_table');
+        expect(revokes).toHaveLength(1);
+        expect(revokes[0].sql).toContain('REVOKE INSERT, UPDATE ON');
+        expect(revokes[0].sql).toContain('FROM "app_user"');
+        expect(findOps(result.operations, 'grant_table')).toHaveLength(0);
+      });
+
+      // Regression for Issue 1: a single YAML grant block that mixes
+      // DELETE (table-only) with column-qualified INSERT/SELECT/UPDATE gets
+      // stored by Postgres as two separate grant rows. The planner and drift
+      // now normalize both sides before comparing.
+      it('emits no ops when YAML mixes DELETE with column-qualified privs and DB stores them split', () => {
+        const desired = emptyDesired();
+        desired.tables = [
+          {
+            table: 'user_preferences',
+            columns: [
+              { name: 'user_preference_id', type: 'serial', primary_key: true },
+              { name: 'key', type: 'varchar(100)' },
+            ],
+            grants: [
+              {
+                to: 'app_user',
+                privileges: ['DELETE', 'INSERT', 'SELECT', 'UPDATE'],
+                columns: ['key', 'user_preference_id'],
+              },
+            ],
+          },
+        ];
+        // Postgres splits the mixed block into a column-level grant (for
+        // SELECT/INSERT/UPDATE) and a table-level grant (for DELETE).
+        const actual = emptyActual();
+        actual.tables.set('user_preferences', {
+          table: 'user_preferences',
+          columns: [
+            { name: 'user_preference_id', type: 'serial', primary_key: true },
+            { name: 'key', type: 'varchar(100)' },
+          ],
+          grants: [
+            {
+              to: 'app_user',
+              privileges: ['INSERT', 'SELECT', 'UPDATE'],
+              columns: ['key', 'user_preference_id'],
+            },
+            { to: 'app_user', privileges: ['DELETE'] },
+          ],
+        });
+        const result = buildPlan(desired, actual);
+        expect(findOps(result.operations, 'grant_table')).toHaveLength(0);
+        expect(findOps(result.operations, 'grant_column')).toHaveLength(0);
+        expect(findOps(result.operations, 'revoke_table')).toHaveLength(0);
+        expect(findOps(result.operations, 'revoke_column')).toHaveLength(0);
+      });
+    });
+
     it('creates table with unique constraints', () => {
       const desired = emptyDesired();
       desired.tables = [

--- a/src/planner/index.ts
+++ b/src/planner/index.ts
@@ -951,12 +951,19 @@ function alterTableOps(desired: TableSchema, existing: TableSchema, pgSchema: st
   // Diff policies
   ops.push(...diffPolicies(desired.table, desired.policies || [], existing.policies || [], pgSchema));
 
-  // Diff grants
+  // Diff grants. Previously this blindly re-emitted every declared grant on
+  // every run — the plan's biggest source of noise for no-op migrations.
+  // Now we compare the normalized desired vs existing grant sets and only
+  // emit the delta (GRANT for newly-declared privileges, REVOKE for ones
+  // removed from YAML).
+  ops.push(...diffGrants(desired.table, desired.grants || [], existing.grants || [], pgSchema));
+
+  // Sequence grants are auto-derived from table grants for serial/bigserial
+  // columns and aren't yet introspected back, so we still emit them blindly
+  // here. They use `GRANT USAGE, SELECT` which is idempotent in Postgres
+  // (no error, no re-grant), but they do still count against the plan size.
+  // Follow-up: introspect sequence privileges and diff them here too.
   if (desired.grants) {
-    for (const grant of desired.grants) {
-      ops.push(createGrantOp(desired.table, grant, pgSchema));
-    }
-    // Auto-generate sequence grants for serial/bigserial columns
     ops.push(...createSequenceGrantOps(desired.table, desired.columns, desired.grants, pgSchema));
   }
 
@@ -1517,6 +1524,131 @@ function createPolicyOp(table: string, policy: PolicyDef, pgSchema: string): Ope
 
 // ─── Grants ────────────────────────────────────────────────────
 
+// Postgres splits grant storage by privilege kind: privileges that can be
+// column-qualified (SELECT, INSERT, UPDATE, REFERENCES) land in
+// information_schema.column_privileges when the grant names columns; the
+// rest (DELETE, TRUNCATE, TRIGGER) live only in table_privileges. A single
+// YAML block mixing both kinds is perfectly expressible, but when we diff
+// YAML ↔ DB we have to compare against the split shape Postgres actually
+// stores, or we mistake one mixed block for two mismatched grants.
+const COLUMN_GRANTABLE_PRIVILEGES = new Set(['SELECT', 'INSERT', 'UPDATE', 'REFERENCES']);
+
+/**
+ * Split any grant that mixes column-qualified privileges with table-only
+ * privileges into the two shapes Postgres stores internally. Idempotent for
+ * grants that are already purely one or the other. Used on both sides of
+ * the grant diff (planner + drift) so the two sides always compare apples
+ * to apples.
+ */
+export function normalizeGrants(grants: GrantDef[]): GrantDef[] {
+  const normalized: GrantDef[] = [];
+  for (const g of grants) {
+    if (!g.columns || g.columns.length === 0) {
+      normalized.push(g);
+      continue;
+    }
+    const colPrivs = g.privileges.filter((p) => COLUMN_GRANTABLE_PRIVILEGES.has(p.toUpperCase()));
+    const tablePrivs = g.privileges.filter((p) => !COLUMN_GRANTABLE_PRIVILEGES.has(p.toUpperCase()));
+    if (colPrivs.length > 0) {
+      const part: GrantDef = { to: g.to, privileges: colPrivs, columns: g.columns };
+      if (g.with_grant_option) part.with_grant_option = true;
+      normalized.push(part);
+    }
+    if (tablePrivs.length > 0) {
+      const part: GrantDef = { to: g.to, privileges: tablePrivs };
+      if (g.with_grant_option) part.with_grant_option = true;
+      normalized.push(part);
+    }
+  }
+  return normalized;
+}
+
+/**
+ * Stable key for a grant identity (grantee + optional columns). Privileges
+ * are compared separately so we can emit partial revokes/grants when they
+ * differ.
+ */
+function grantIdentityKey(g: GrantDef): string {
+  const cols = g.columns && g.columns.length > 0 ? [...g.columns].sort().join(',') : '';
+  return `${g.to}::${cols}`;
+}
+
+/**
+ * Compute the minimum set of GRANT / REVOKE ops to reconcile `existing`
+ * (introspected from the DB) with `desired` (from YAML). Normalizes both
+ * sides first so a single YAML block mixing column-qualified and table-only
+ * privileges compares correctly against the split shape Postgres stores.
+ *
+ * Issues a REVOKE for privileges present in the DB but not desired, a GRANT
+ * for privileges desired but absent, and no op when both sides agree.
+ * `with_grant_option` changes force a re-grant (REVOKE … GRANT OPTION FOR
+ * then GRANT … WITH GRANT OPTION) — Postgres has no single ALTER for this.
+ */
+function diffGrants(table: string, desired: GrantDef[], existing: GrantDef[], pgSchema: string): Operation[] {
+  const ops: Operation[] = [];
+  const normDesired = normalizeGrants(desired);
+  const normExisting = normalizeGrants(existing);
+
+  const desiredByKey = new Map<string, GrantDef[]>();
+  for (const g of normDesired) {
+    const k = grantIdentityKey(g);
+    const arr = desiredByKey.get(k);
+    if (arr) arr.push(g);
+    else desiredByKey.set(k, [g]);
+  }
+  const existingByKey = new Map<string, GrantDef[]>();
+  for (const g of normExisting) {
+    const k = grantIdentityKey(g);
+    const arr = existingByKey.get(k);
+    if (arr) arr.push(g);
+    else existingByKey.set(k, [g]);
+  }
+
+  const allKeys = new Set<string>([...desiredByKey.keys(), ...existingByKey.keys()]);
+  for (const key of allKeys) {
+    const desiredAgg = aggregateByGrantOption(desiredByKey.get(key) ?? []);
+    const existingAgg = aggregateByGrantOption(existingByKey.get(key) ?? []);
+
+    for (const [wgo, desiredPrivs] of desiredAgg.entries()) {
+      const existingPrivs = existingAgg.get(wgo) ?? new Set<string>();
+      const toGrant = [...desiredPrivs].filter((p) => !existingPrivs.has(p)).sort();
+      if (toGrant.length === 0) continue;
+      const sample = (desiredByKey.get(key) ?? []).find((g) => !!g.with_grant_option === wgo);
+      if (!sample) continue;
+      ops.push(
+        createGrantOp(
+          table,
+          { to: sample.to, privileges: toGrant, columns: sample.columns, with_grant_option: wgo },
+          pgSchema,
+        ),
+      );
+    }
+    for (const [wgo, existingPrivs] of existingAgg.entries()) {
+      const desiredPrivs = desiredAgg.get(wgo) ?? new Set<string>();
+      const toRevoke = [...existingPrivs].filter((p) => !desiredPrivs.has(p)).sort();
+      if (toRevoke.length === 0) continue;
+      const sample = (existingByKey.get(key) ?? []).find((g) => !!g.with_grant_option === wgo);
+      if (!sample) continue;
+      ops.push(createRevokeOp(table, { ...sample, privileges: toRevoke }, pgSchema));
+    }
+  }
+  return ops;
+}
+
+function aggregateByGrantOption(grants: GrantDef[]): Map<boolean, Set<string>> {
+  const out = new Map<boolean, Set<string>>();
+  for (const g of grants) {
+    const wgo = !!g.with_grant_option;
+    let set = out.get(wgo);
+    if (!set) {
+      set = new Set();
+      out.set(wgo, set);
+    }
+    for (const p of g.privileges) set.add(p.toUpperCase());
+  }
+  return out;
+}
+
 function createGrantOp(table: string, grant: GrantDef, pgSchema: string): Operation {
   const privileges = grant.privileges.join(', ');
   const isColumnGrant = grant.columns && grant.columns.length > 0;
@@ -1535,6 +1667,25 @@ function createGrantOp(table: string, grant: GrantDef, pgSchema: string): Operat
     objectName: `${table}.${grant.to}`,
     sql,
     destructive: false,
+  };
+}
+
+function createRevokeOp(table: string, grant: GrantDef, pgSchema: string): Operation {
+  const privileges = grant.privileges.join(', ');
+  const isColumnGrant = grant.columns && grant.columns.length > 0;
+  let target: string;
+  if (isColumnGrant) {
+    const cols = grant.columns!.map((c) => `"${c}"`).join(', ');
+    target = `${privileges} (${cols}) ON "${pgSchema}"."${table}"`;
+  } else {
+    target = `${privileges} ON "${pgSchema}"."${table}"`;
+  }
+  return {
+    type: isColumnGrant ? 'revoke_column' : 'revoke_table',
+    phase: 13,
+    objectName: `${table}.${grant.to}`,
+    sql: `REVOKE ${target} FROM "${grant.to}"`,
+    destructive: true,
   };
 }
 


### PR DESCRIPTION
Closes #17 (Issue 1 + Issue 2, partial Issue 3).

## The problem

**Issue 2 — planner re-applies all grants on every run.** `alterTableOps` used to call `createGrantOp` blindly for every declared grant, so a no-op second run produced hundreds of redundant ops (`Plan: 246 operations` where the bulk were `Granted X.app_user` lines for every table in the schema).

**Issue 1 — drift false positive on mixed blocks.** A single YAML grant block mixing `DELETE` (table-only) with column-qualified `INSERT/SELECT/UPDATE` is perfectly valid, but Postgres stores it as two rows (column_privileges + table_privileges). Drift saw one grant in YAML and two in DB, reporting three mismatches on an otherwise-clean database.

## The fix

Two helpers in `src/planner/index.ts`:

- **`normalizeGrants(grants)`** splits any mixed block into the separate column-level + table-level rows Postgres stores. Idempotent for grants that are already purely one or the other. Exported so drift can share the normalization.
- **`diffGrants(table, desired, existing, pgSchema)`** computes the minimum `GRANT` / `REVOKE` delta between normalized sides. New `revoke_table` / `revoke_column` ops cover privileges removed from YAML. `with_grant_option` is tracked alongside the privilege set.

Wiring:

- `alterTableOps` now calls `diffGrants` instead of looping `createGrantOp`. New tables still emit everything in `createTableOps` since there's nothing to diff against.
- `drift/index.ts` normalizes both sides before comparison.

Log accuracy (partial Issue 3):

- `cli/report.ts` suppresses `Seeded: X (N unchanged)` lines in default mode when nothing was inserted or updated. Verbose mode still shows them for debugging.
- `Added index: X` on no-op runs is a separate symptom rooted deeper in the planner's unique-constraint handling — tracked as a follow-up.
- Sequence grants (`grant_sequence` for serial/bigserial cols) are still blindly emitted — the introspector doesn't read sequence privileges yet. They're idempotent at the Postgres level (`GRANT USAGE/SELECT` is a no-op if already granted) but still count against the plan size. Tracked as a follow-up.

## Test plan

- [x] `pnpm lint` green
- [x] `pnpm typecheck` green
- [x] `pnpm build` green
- [ ] `pnpm test` — unable to run locally; see note on PR #20. CI will cover.

New tests:
- Four in `planner.test.ts` covering: no-op when desired == existing, partial grant, partial revoke, and the mixed-block round-trip from Issue 1.
- One in `drift.test.ts` covering the mixed-block round-trip.
- Three in a new `cli/__tests__/report.test.ts` covering seed-suppression behavior.

## Impact for users

- A no-op migration run against a large schema drops from hundreds of grant ops to zero. Real schema changes become easy to spot in the log.
- The mixed-block form that Issue 1 describes is no longer a workaround hazard — users can write grants in whichever form fits their mental model.
- Grants that get manually added to the DB outside schema-flow will now be revoked on the next run (previously they'd be preserved as noise). Worth noting in the changelog; if any user relies on "extra grants are ignored" semantics they'll want to declare them in YAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)