### PR TITLE
chore: sync 0.4.0 version bump into main

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smplcty/schema-flow",
-  "version": "0.3.7",
+  "version": "0.4.0",
   "description": "Declarative PostgreSQL schema management tool",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Problem

`pnpm release:minor` was accidentally run from the `feat/expression-indexes` branch (not `main`), so the `package.json` bump from `0.3.7` → `0.4.0` lives on the tag (`v0.4.0`, commit `3a4ee80`) but never made it onto `main`. Current state:

- **npm**: `@smplcty/schema-flow@0.4.0` published ✓ (publish workflow ran cleanly from the tag)
- **GitHub Release `v0.4.0`**: exists ✓
- **`main` branch's `package.json`**: still `0.3.7` ✗
- **Tag `v0.4.0`**: points at a commit on the merged feature branch, not reachable from `main`'s history

If this PR merges as-is, the next `pnpm release:patch/minor/major` will correctly bump from `0.4.0` onward. Without this, the next release-it run would try to bump from `0.3.7`, clashing with the already-published `0.4.0`.

## What this PR does

One-line cherry-pick of the version-bump commit (`3a4ee80`) onto `main`. Just `package.json: "version": "0.3.7"` → `"0.4.0"`. No code changes.

## After merging

The tag `v0.4.0` will still point at the orphan commit on the merged feature branch, not at the new commit on `main`. Two options:

1. **Leave it.** npm is correct, GitHub Release is correct, main's version is correct. Only cost: `git describe main` won't find the tag (it's not in main's ancestry). Cosmetic.
2. **Move the tag to main's new HEAD** so the ancestry is clean:
   ```bash
   git fetch origin
   git tag -f v0.4.0 origin/main
   git push --force origin v0.4.0
   ```
   No re-publish happens because the publish workflow fires on `release.published`, not on tag updates. The GitHub Release stays associated with the tag name.

Recommend option 2 for hygiene. Happy to do that immediately after merge if you confirm.