### PR TITLE
ci: refuse to publish or deploy docs when tag isn't on main

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -46,5 +46,21 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
+      - uses: actions/checkout@v4
+        with:
+          # Full history so we can check if the tag's commit is on main.
+          fetch-depth: 0
+
+      # Refuse to deploy docs unless the tag is reachable from main. Pair
+      # with the identical check in publish.yml — neither npm nor docs
+      # should ship for a tag that wasn't cut from main.
+      - name: Refuse to deploy if tag isn't on main
+        run: |
+          git fetch origin main
+          if ! git merge-base --is-ancestor "${{ github.sha }}" origin/main; then
+            echo "::error::Tag ${{ github.ref_name }} (commit ${{ github.sha }}) is not reachable from main. Refusing to deploy docs. Re-run the release from main."
+            exit 1
+          fi
+
       - id: deployment
         uses: actions/deploy-pages@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,21 @@ jobs:
     environment: npm
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Full history so we can check if the tag's commit is on main.
+          fetch-depth: 0
+
+      # Refuse to publish unless the tag is reachable from main. Catches
+      # accidental release-it runs from a feature branch before it's merged
+      # (see history around v0.4.0). Pair with the identical check in
+      # deploy-docs.yml so both paths are protected.
+      - name: Refuse to publish if tag isn't on main
+        run: |
+          git fetch origin main
+          if ! git merge-base --is-ancestor "${{ github.sha }}" origin/main; then
+            echo "::error::Tag ${{ github.ref_name }} (commit ${{ github.sha }}) is not reachable from main. Refusing to publish. Re-run the release from main."
+            exit 1
+          fi
 
       - uses: pnpm/action-setup@v4
 


### PR DESCRIPTION
## Context

v0.4.0 was cut accidentally from the `feat/expression-indexes` branch before it had merged to `main`. The publish workflow ran from that off-main tag and pushed `0.4.0` to npm. The docs deploy also tried to run and was blocked — but only because an unrelated environment protection rule coincidentally rejected the tag. It was the wrong signal for the right reason; if that rule hadn't existed, docs would also have shipped from an off-main tag without complaint.

The fix for that specific incident was cherry-picking the version-bump commit onto main and force-moving the tag. But nothing stopped the mistake from happening in the first place, and nothing will stop it next time. This PR fixes that.

## Change

Both `publish.yml` and `deploy-docs.yml` gain a first step that fails the job with a clear message if `github.sha` (the tagged commit) isn't reachable from `origin/main`. If a future `pnpm release:*` run happens from a branch that hasn't been merged to main yet, the workflow fails loudly before npm or Pages are touched:

```
Tag v0.5.0 (commit abc1234) is not reachable from main. Refusing to publish.
Re-run the release from main.
```

Both workflows switch the checkout to `fetch-depth: 0` so the ancestry check has full history to walk.

No behavior change for correctly-cut release tags from main.

## Related environment change (already applied)

The `github-pages` environment had a deployment-branch-policy limiting deploys to the `main` branch only. Release-triggered runs use a tag ref, not a branch, so every release had been failing the docs deploy since at least v0.3.4 — unrelated to the off-main-tag mistake. Added a `v*` tag policy to the same environment (via GH API, outside this PR's diff) so release-triggered deploys can actually run. The combination — env policy allows `v*` tags, workflow refuses tags not on main — is the minimum set for releases to deploy docs correctly while still rejecting off-main tags.

## Test plan

Can't test the failing path locally without cutting a deliberate off-main tag. The happy path is exercised on every real release; first proof will come with the next release-from-main.

After merge, re-trigger the v0.4.0 docs deploy (which is now on main and should pass both checks):

```bash
gh workflow run deploy-docs.yml -R mabulu-inc/simplicity-schema-flow --ref v0.4.0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)