### PR TITLE
ci: bump GitHub Actions to latest majors (Node 24 runtime)

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -21,11 +21,11 @@ jobs:
       run:
         working-directory: docs-site
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: pnpm
@@ -35,7 +35,7 @@ jobs:
 
       - run: pnpm build
 
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: docs-site/dist
 
@@ -46,7 +46,7 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           # Full history so we can check if the tag's commit is on main.
           fetch-depth: 0
@@ -63,4 +63,4 @@ jobs:
           fi
 
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: npm
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           # Full history so we can check if the tag's commit is on main.
           fetch-depth: 0
@@ -30,9 +30,9 @@ jobs:
             exit 1
           fi
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: pnpm


### PR DESCRIPTION
## Why

The Node 20 runtime targeted by the old action majors is deprecated — GitHub forces Node 24 as the default on **2026-06-02** and removes Node 20 entirely on **2026-09-16**. Every workflow run since v0.3.4 has been annotated with the deprecation warning for each action still pinned to the old major.

## What

Five bumps across `publish.yml` and `deploy-docs.yml`:

| Action | Before | After |
|---|---|---|
| `actions/checkout` | v4 | v6 |
| `actions/setup-node` | v4 | v6 |
| `actions/upload-pages-artifact` | v3 | v5 |
| `actions/deploy-pages` | v4 | v5 |
| `pnpm/action-setup` | v4 | v5 |

All current latest majors per their repos. All run on Node 24.

No behavior change expected for our usage — the inputs these workflows pass (`node-version`, `cache`, `registry-url`, `fetch-depth`, etc.) are unchanged across the major boundary.

## Test plan

Can't fully exercise locally. The happy path runs on every release. The v0.4.0 docs deploy re-trigger just before this PR proved that the current (old) versions work against `v0.4.0`; the next release will prove the new versions work end-to-end.

If any of the bumped majors broke an input shape we depend on, CI would fail loudly — lower-risk to merge and validate on the next release than to defer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)