### PR TITLE
planner: eliminate two false-positive drift sources (#32, #33)

### DIFF
--- a/src/planner/__tests__/planner.test.ts
+++ b/src/planner/__tests__/planner.test.ts
@@ -2352,6 +2352,32 @@ describe('Planner', () => {
       expect(ops).toHaveLength(1);
       expect(ops[0].sql).toContain('"writer"');
     });
+
+    it('dedupes grant_sequence when one role has multiple write-privilege grant blocks', () => {
+      // Common YAML pattern: a column-qualified grant for INSERT/SELECT/UPDATE
+      // and a table-level grant for DELETE alongside it. Both blocks expand
+      // to the same per-sequence GRANT for the same role, so the planner
+      // must collapse them to a single op.
+      const desired = emptyDesired();
+      desired.tables = [
+        {
+          table: 'items',
+          columns: [
+            { name: 'id', type: 'serial', primary_key: true },
+            { name: 'name', type: 'text' },
+          ],
+          grants: [
+            { to: 'app_user', privileges: ['INSERT', 'SELECT', 'UPDATE'], columns: ['id', 'name'] },
+            { to: 'app_user', privileges: ['DELETE', 'INSERT', 'SELECT', 'UPDATE'] },
+          ],
+        },
+      ];
+      const result = buildPlan(desired, emptyActual());
+      const ops = findOps(result.operations, 'grant_sequence');
+      expect(ops).toHaveLength(1);
+      expect(ops[0].sql).toContain('"app_user"');
+      expect(ops[0].sql).toContain('items_id_seq');
+    });
   });
 
   describe('CONCURRENTLY indexes', () => {

--- a/src/planner/index.ts
+++ b/src/planner/index.ts
@@ -2002,21 +2002,29 @@ function createSequenceGrantOps(
   grants: GrantDef[],
   pgSchema: string,
 ): Operation[] {
-  const ops: Operation[] = [];
   const serialCols = columns.filter((c) => SERIAL_TYPES.has(c.type.toLowerCase()));
-  if (serialCols.length === 0) return ops;
+  if (serialCols.length === 0) return [];
+
+  // Tables commonly declare multiple grant blocks for the same role to
+  // mix column-qualified and table-level privileges; both blocks expand
+  // to the same per-sequence GRANT, which Postgres treats as identical.
+  // Dedupe keyed on (sequence, role) to keep the plan one-op-per-effect.
+  const seen = new Set<string>();
+  const ops: Operation[] = [];
 
   for (const grant of grants) {
-    // Only generate sequence grants for roles that need write access
     const needsSequence = grant.privileges.some((p) => SEQUENCE_NEEDING_PRIVILEGES.has(p.toUpperCase()));
     if (!needsSequence) continue;
 
     for (const col of serialCols) {
       const seqName = `${table}_${col.name}_seq`;
+      const key = `${seqName}.${grant.to}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
       ops.push({
         type: 'grant_sequence',
         phase: 13,
-        objectName: `${seqName}.${grant.to}`,
+        objectName: key,
         sql: `GRANT USAGE, SELECT ON SEQUENCE "${pgSchema}"."${seqName}" TO "${grant.to}"`,
         destructive: false,
       });

--- a/src/planner/normalize-expression.ts
+++ b/src/planner/normalize-expression.ts
@@ -45,8 +45,11 @@ async function normalizeExpression(
   expression: string,
   kind: 'using' | 'check',
 ): Promise<string> {
-  const suffix = Math.random().toString(36).slice(2, 10);
-  const tempTable = `_sf_norm_${suffix}`;
+  // The temp table reuses the real table name so self-qualified
+  // references in the expression (`yards.region_id`) resolve against the
+  // temp's columns — pg_temp is searched first on search_path and
+  // shadows any persistent same-named table for the savepoint's lifetime.
+  const tempTable = table.table;
   const policyName = '_sf_norm_policy';
 
   await client.query('SAVEPOINT normalize_expr');
@@ -64,7 +67,8 @@ async function normalizeExpression(
       `SELECT ${exprColumn} AS expr
        FROM pg_catalog.pg_policy pol
        JOIN pg_catalog.pg_class cls ON cls.oid = pol.polrelid
-       WHERE cls.relname = $1 AND pol.polname = $2`,
+       WHERE cls.relname = $1 AND pol.polname = $2
+         AND cls.relnamespace = pg_my_temp_schema()`,
       [tempTable, policyName],
     );
 
@@ -112,8 +116,8 @@ export async function normalizeCheckExpressions(client: PoolClient, tables: Tabl
 }
 
 async function normalizeCheckExpression(client: PoolClient, table: TableSchema, expression: string): Promise<string> {
-  const suffix = Math.random().toString(36).slice(2, 10);
-  const tempTable = `_sf_norm_${suffix}`;
+  // See normalizeExpression for the temp-table-shadows-real-table rationale.
+  const tempTable = table.table;
   const constraintName = `_sf_norm_check`;
 
   await client.query('SAVEPOINT normalize_check');
@@ -126,7 +130,8 @@ async function normalizeCheckExpression(client: PoolClient, table: TableSchema, 
       `SELECT pg_get_constraintdef(con.oid, true) AS def
        FROM pg_catalog.pg_constraint con
        JOIN pg_catalog.pg_class cls ON cls.oid = con.conrelid
-       WHERE cls.relname = $1 AND con.conname = $2`,
+       WHERE cls.relname = $1 AND con.conname = $2
+         AND cls.relnamespace = pg_my_temp_schema()`,
       [tempTable, constraintName],
     );
 
@@ -165,8 +170,9 @@ export async function normalizeIndexWhereClauses(client: PoolClient, tables: Tab
 }
 
 async function normalizeIndexWhere(client: PoolClient, table: TableSchema, where: string): Promise<string> {
+  // See normalizeExpression for the temp-table-shadows-real-table rationale.
+  const tempTable = table.table;
   const suffix = Math.random().toString(36).slice(2, 10);
-  const tempTable = `_sf_norm_${suffix}`;
   const tempIdx = `_sf_norm_idx_${suffix}`;
   // Pick the first column for the index key — only the WHERE clause's
   // canonical form matters here; the key column is irrelevant.
@@ -183,7 +189,9 @@ async function normalizeIndexWhere(client: PoolClient, table: TableSchema, where
       `SELECT pg_get_expr(ix.indpred, ix.indrelid) AS expr
        FROM pg_catalog.pg_index ix
        JOIN pg_catalog.pg_class i ON i.oid = ix.indexrelid
-       WHERE i.relname = $1`,
+       JOIN pg_catalog.pg_namespace ns ON ns.oid = i.relnamespace
+       WHERE i.relname = $1
+         AND ns.oid = pg_my_temp_schema()`,
       [tempIdx],
     );
 

--- a/test/e2e/no-churn-on-reapply.test.ts
+++ b/test/e2e/no-churn-on-reapply.test.ts
@@ -100,4 +100,52 @@ checks:
     expect(second.executedOperations).toEqual([]);
     expect(second.executed).toBe(0);
   });
+
+  it('self-qualified policy USING / CHECK / partial-index WHERE re-applies as a no-op (#32)', async () => {
+    // Covers the common RLS pattern of writing `tablename.col` inside an
+    // EXISTS subquery so the inner FROM disambiguates joined tables, and
+    // the same shape inside CHECK and partial-index WHERE clauses.
+    ctx = await useTestProject(DATABASE_URL);
+
+    writeSchema(ctx.dir, {
+      'tables/things.yaml': `
+table: things
+rls: true
+columns:
+  - name: thing_id
+    type: integer
+    primary_key: true
+  - name: owner_id
+    type: integer
+    nullable: false
+  - name: status
+    type: text
+    nullable: false
+checks:
+  - name: things_owner_positive
+    expression: things.owner_id > 0
+indexes:
+  - name: idx_things_active_owner
+    columns: [owner_id]
+    where: things.status <> 'archived'
+policies:
+  - name: things_owner_visibility
+    for: SELECT
+    to: PUBLIC
+    using: |-
+      EXISTS (
+        SELECT 1 FROM things t2
+        WHERE t2.owner_id = things.owner_id
+          AND t2.status = things.status
+      )
+`,
+    });
+
+    const first = await runMigration(ctx);
+    expect(first.executed).toBeGreaterThan(0);
+
+    const second = await runMigration(ctx);
+    expect(second.executedOperations).toEqual([]);
+    expect(second.executed).toBe(0);
+  });
 });


### PR DESCRIPTION
Two independent planner fixes, both surfaced from a real-world repo whose 0-op replay still emitted ~150 ops post-#26.

## Commit 1 — temp-table self-reference fix (closes #32)

Three round-trip normalisers (`normalizeExpression`, `normalizeCheckExpression`, `normalizeIndexWhere`) created their temp table with a randomised name. Self-qualified references in the YAML expression (`yards.region_id`, `orders.id`) failed to resolve when CREATE POLICY/ALTER TABLE was run against the random-named temp, the catch silently returned the un-normalised text, and the diff churned every plan.

Use the real table name. `pg_temp` is searched first on `search_path` and shadows any persistent same-named table for the savepoint's lifetime, so self-qualified references resolve to the temp's columns. Lookup queries gain a `pg_my_temp_schema()` filter so the readback can't see same-named persistent objects.

E2E regression added covering all three normalisers with self-qualified references inside an EXISTS subquery — the common RLS pattern.

## Commit 2 — grant_sequence dedupe (closes #33)

`createSequenceGrantOps` iterated per-grant-block. Tables with two grant blocks for the same role (column-qualified + table-level — a common pattern for splitting column-level INSERT/SELECT/UPDATE from table-level DELETE) emitted byte-identical grant_sequence ops twice.

Dedupe inside the loop by `(sequence, role)`. Same effect on first apply, single line in the plan output thereafter.

Unit test added.

## Test results

\`pnpm check\` clean. Suite: 80 files / 1210 tests passing.

## Verified against real repo

The reporting repo had 44 policy churns + 108 grant_sequence emits (54 sequences × 2). Locally rebuilt against this branch, both classes drop to zero in the plan.