### PR TITLE
planner: suppress seed_table emission when rows match the database (#35)

### DIFF
--- a/src/cli/pipeline.ts
+++ b/src/cli/pipeline.ts
@@ -26,6 +26,7 @@ import {
   normalizeCheckExpressions,
   normalizeIndexWhereClauses,
 } from '../planner/normalize-expression.js';
+import { filterUnchangedSeeds } from '../planner/filter-seeds.js';
 import { execute } from '../executor/index.js';
 import type { ExecuteResult } from '../executor/index.js';
 import { getPool } from '../core/db.js';
@@ -88,6 +89,7 @@ export async function runPipeline(
       await normalizePolicyExpressions(normClient, desired.tables);
       await normalizeCheckExpressions(normClient, desired.tables);
       await normalizeIndexWhereClauses(normClient, desired.tables);
+      await filterUnchangedSeeds(normClient, desired.tables, config.pgSchema);
     } finally {
       normClient.release();
     }

--- a/src/planner/filter-seeds.ts
+++ b/src/planner/filter-seeds.ts
@@ -1,0 +1,111 @@
+/**
+ * Suppress seed_table emission when every YAML seed row already exists
+ * verbatim in the target database. Mutates `table.seeds` to `[]` for
+ * tables whose seeds match exactly, so the planner emits no op for them.
+ *
+ * Strategy: load the YAML seeds into a temp table and EXCEPT-compare
+ * against the real table over the seed-declared columns. If the result
+ * is empty, every seed row has a matching row in the real table.
+ *
+ * Skipped (seeds left intact, planner emits the op as before):
+ *  - tables with seed values that are SQL expressions (`{ __sql: '…' }`)
+ *    — those evaluate at apply time and can't be compared statically;
+ *  - tables whose primary key isn't present in every seed row — without
+ *    a stable identity column we can't tell "row exists with same data"
+ *    from "row exists with different data";
+ *  - first-apply against a fresh DB where the real table doesn't exist
+ *    yet — the EXCEPT throws, the catch leaves seeds intact.
+ */
+
+import type { PoolClient } from 'pg';
+import type { TableSchema } from '../schema/types.js';
+
+export async function filterUnchangedSeeds(client: PoolClient, tables: TableSchema[], pgSchema: string): Promise<void> {
+  const candidates = tables.filter((t) => t.table && t.seeds && t.seeds.length > 0);
+  if (candidates.length === 0) return;
+
+  await client.query('BEGIN');
+  try {
+    await processCandidates(client, candidates, pgSchema);
+  } finally {
+    await client.query('ROLLBACK').catch(() => {});
+  }
+}
+
+async function processCandidates(client: PoolClient, candidates: TableSchema[], pgSchema: string): Promise<void> {
+  for (const table of candidates) {
+    const seeds = table.seeds!;
+
+    if (seeds.some((row) => Object.values(row).some(isSqlExpression))) continue;
+
+    const seedColumns = collectSeedColumns(seeds);
+    const pkCols = (table.columns ?? []).filter((c) => c.primary_key).map((c) => c.name);
+    if (pkCols.length === 0) continue;
+    if (!pkCols.every((c) => seedColumns.includes(c))) continue;
+
+    const colDefMap = new Map((table.columns ?? []).map((c) => [c.name, mapColumnType(c.type)]));
+    if (!seedColumns.every((c) => colDefMap.has(c))) continue;
+
+    await client.query('SAVEPOINT filter_seeds');
+    try {
+      const tempName = `_sf_seed_${Math.random().toString(36).slice(2, 10)}`;
+      const colDefs = seedColumns.map((c) => `"${c}" ${colDefMap.get(c)}`).join(', ');
+      await client.query(`CREATE TEMP TABLE "${tempName}" (${colDefs})`);
+
+      const params: unknown[] = [];
+      const valueLines = seeds.map((row) => {
+        const placeholders = seedColumns.map((c) => {
+          params.push(row[c] ?? null);
+          return `$${params.length}`;
+        });
+        return `(${placeholders.join(', ')})`;
+      });
+      const colList = seedColumns.map((c) => `"${c}"`).join(', ');
+      await client.query(`INSERT INTO "${tempName}" (${colList}) VALUES ${valueLines.join(', ')}`, params);
+
+      const diff = await client.query(
+        `SELECT 1 FROM (
+           SELECT ${colList} FROM "${tempName}"
+           EXCEPT
+           SELECT ${colList} FROM "${pgSchema}"."${table.table}"
+         ) d LIMIT 1`,
+      );
+
+      if (diff.rows.length === 0) {
+        table.seeds = [];
+      }
+    } catch {
+      // Real table missing, type mismatch in temp insert, or EXCEPT
+      // column-resolution failure — leave seeds intact, planner emits
+      // the op as before.
+    } finally {
+      await client.query('ROLLBACK TO filter_seeds').catch(() => {});
+    }
+  }
+}
+
+function isSqlExpression(val: unknown): boolean {
+  return (
+    typeof val === 'object' && val !== null && '__sql' in val && typeof (val as { __sql: string }).__sql === 'string'
+  );
+}
+
+function collectSeedColumns(seeds: Record<string, unknown>[]): string[] {
+  const seen = new Set<string>();
+  const ordered: string[] = [];
+  for (const row of seeds) {
+    for (const key of Object.keys(row)) {
+      if (!seen.has(key)) {
+        seen.add(key);
+        ordered.push(key);
+      }
+    }
+  }
+  return ordered;
+}
+
+function mapColumnType(type: string): string {
+  const lower = type.toLowerCase();
+  if (lower === 'serial' || lower === 'bigserial' || lower === 'smallserial') return 'integer';
+  return type;
+}

--- a/test/e2e/no-churn-on-reapply.test.ts
+++ b/test/e2e/no-churn-on-reapply.test.ts
@@ -101,6 +101,89 @@ checks:
     expect(second.executed).toBe(0);
   });
 
+  it('seeds whose rows already exist verbatim re-apply as a no-op', async () => {
+    // Idempotent INSERT/UPDATE makes seed re-application correct on the
+    // executor side, but the planner emitted a seed_table op every plan
+    // regardless. With pre-flight comparison via temp-table EXCEPT, the
+    // op is suppressed when every seed row matches the live data.
+    ctx = await useTestProject(DATABASE_URL);
+
+    writeSchema(ctx.dir, {
+      'tables/colors.yaml': `
+table: colors
+columns:
+  - name: color_id
+    type: integer
+    primary_key: true
+  - name: name
+    type: text
+    nullable: false
+seeds:
+  - color_id: 1
+    name: red
+  - color_id: 2
+    name: green
+  - color_id: 3
+    name: blue
+seeds_on_conflict: 'DO NOTHING'
+`,
+    });
+
+    const first = await runMigration(ctx);
+    expect(first.executed).toBeGreaterThan(0);
+
+    const second = await runMigration(ctx);
+    expect(second.executedOperations).toEqual([]);
+    expect(second.executed).toBe(0);
+  });
+
+  it('seed_table is still emitted when YAML adds a new row', async () => {
+    ctx = await useTestProject(DATABASE_URL);
+
+    writeSchema(ctx.dir, {
+      'tables/colors.yaml': `
+table: colors
+columns:
+  - name: color_id
+    type: integer
+    primary_key: true
+  - name: name
+    type: text
+    nullable: false
+seeds:
+  - color_id: 1
+    name: red
+seeds_on_conflict: 'DO NOTHING'
+`,
+    });
+
+    await runMigration(ctx);
+
+    // Add a second seed row — the planner must still emit the op.
+    writeSchema(ctx.dir, {
+      'tables/colors.yaml': `
+table: colors
+columns:
+  - name: color_id
+    type: integer
+    primary_key: true
+  - name: name
+    type: text
+    nullable: false
+seeds:
+  - color_id: 1
+    name: red
+  - color_id: 2
+    name: green
+seeds_on_conflict: 'DO NOTHING'
+`,
+    });
+
+    const second = await runMigration(ctx);
+    const seedOps = second.executedOperations.filter((o) => o.type === 'seed_table');
+    expect(seedOps).toHaveLength(1);
+  });
+
   it('self-qualified policy USING / CHECK / partial-index WHERE re-applies as a no-op (#32)', async () => {
     // Covers the common RLS pattern of writing `tablename.col` inside an
     // EXISTS subquery so the inner FROM disambiguates joined tables, and


### PR DESCRIPTION
Closes #35.

A pre-flight comparison loads each table's YAML seeds into a temp table and `EXCEPT`-compares against the real table over the seed-declared columns. If every seed row matches an existing row, `table.seeds` is cleared in the in-memory desired state so the planner emits no op for that table.

The comparison is skipped — and seeds left intact for the planner to emit as before — for cases where static comparison would be wrong:

- A seed value is a SQL expression (`{ __sql: '…' }`).
- The table has no primary key in YAML, or the seeds don't all carry the PK columns.
- The real table doesn't exist yet (first apply on a fresh DB) — the EXCEPT throws, the catch leaves seeds intact.

Two e2e regressions:

- A 3-row seed re-applies as 0 ops.
- Adding a seed row to the YAML still emits the op so the new row gets inserted.

Suite: 80 files / 1212 tests passing.