### PR TITLE
planner: suppress grant_sequence when sequence ACL is already correct (#37)

### DIFF
--- a/src/cli/pipeline.ts
+++ b/src/cli/pipeline.ts
@@ -17,6 +17,7 @@ import {
   getExistingViews,
   getExistingMaterializedViews,
   getExistingRoles,
+  getSequenceGrants,
   introspectTable,
 } from '../introspect/index.js';
 import { buildPlan } from '../planner/index.js';
@@ -268,6 +269,8 @@ async function introspectDatabase(config: SimplicitySchemaConfig, logger: Logger
     const extResult = await client.query("SELECT extname FROM pg_extension WHERE extname != 'plpgsql'");
     const extensions = extResult.rows.map((r: { extname: string }) => r.extname);
 
+    const sequenceGrants = await getSequenceGrants(client, config.pgSchema);
+
     logger.debug(`Introspected: ${tableNames.length} tables, ${enumList.length} enums, ${fnList.length} functions`);
 
     return {
@@ -278,6 +281,7 @@ async function introspectDatabase(config: SimplicitySchemaConfig, logger: Logger
       materializedViews: matViewsMap,
       roles: rolesMap,
       extensions,
+      sequenceGrants,
     };
   } finally {
     client.release();

--- a/src/introspect/index.ts
+++ b/src/introspect/index.ts
@@ -54,6 +54,50 @@ export async function getExistingTables(client: Client, schema: string): Promise
   return result.rows.map((r: { tablename: string }) => r.tablename);
 }
 
+/**
+ * Map of sequence name → role name → Set of privilege types granted on that
+ * sequence to that role. Privilege types match the PG strings: USAGE,
+ * SELECT, UPDATE.
+ */
+export type SequenceGrantMap = Map<string, Map<string, Set<string>>>;
+
+/**
+ * Aggregate existing sequence grants in a schema. Used so the planner can
+ * suppress repeat GRANT ops when the privileges are already in place — GRANT
+ * is idempotent in Postgres but the plan output gets noisy without this.
+ */
+export async function getSequenceGrants(client: Client, schema: string): Promise<SequenceGrantMap> {
+  const result = await client.query(
+    `SELECT c.relname AS seq,
+            pg_get_userbyid(ae.grantee) AS role,
+            ae.privilege_type
+     FROM pg_catalog.pg_class c
+     JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+     CROSS JOIN LATERAL aclexplode(c.relacl) ae
+     WHERE c.relkind = 'S'
+       AND n.nspname = $1
+       AND ae.grantee <> 0
+     ORDER BY c.relname, role, ae.privilege_type`,
+    [schema],
+  );
+
+  const out: SequenceGrantMap = new Map();
+  for (const row of result.rows as { seq: string; role: string; privilege_type: string }[]) {
+    let bySeq = out.get(row.seq);
+    if (!bySeq) {
+      bySeq = new Map();
+      out.set(row.seq, bySeq);
+    }
+    let byRole = bySeq.get(row.role);
+    if (!byRole) {
+      byRole = new Set();
+      bySeq.set(row.role, byRole);
+    }
+    byRole.add(row.privilege_type);
+  }
+  return out;
+}
+
 /** Get all enum types and their values in a schema, excluding extension-owned enums. */
 export async function getExistingEnums(client: Client, schema: string): Promise<EnumSchema[]> {
   const result = await client.query(

--- a/src/planner/index.ts
+++ b/src/planner/index.ts
@@ -145,6 +145,10 @@ export interface ActualState {
   materializedViews: Map<string, MaterializedViewSchema>;
   roles: Map<string, RoleSchema>;
   extensions: string[];
+  /** Sequence grants keyed by sequence → role → granted privilege set.
+   *  Used to suppress repeat grant_sequence ops when the live ACL already
+   *  carries USAGE+SELECT for the role. */
+  sequenceGrants?: Map<string, Map<string, Set<string>>>;
 }
 
 export interface PlanOptions {
@@ -177,7 +181,7 @@ export function buildPlan(desired: DesiredState, actual: ActualState, options: P
   allOps.push(...diffFunctions(desired.functions, actual.functions, pgSchema));
 
   // Diff tables (without FKs first)
-  allOps.push(...diffTables(desired.tables, actual.tables, pgSchema));
+  allOps.push(...diffTables(desired.tables, actual.tables, pgSchema, actual.sequenceGrants));
 
   // Diff views
   allOps.push(...diffViews(desired.views, actual.views, pgSchema));
@@ -519,15 +523,20 @@ function diffFunctions(desired: FunctionSchema[], actual: Map<string, FunctionSc
 
 // ─── Tables ────────────────────────────────────────────────────
 
-function diffTables(desired: TableSchema[], actual: Map<string, TableSchema>, pgSchema: string): Operation[] {
+function diffTables(
+  desired: TableSchema[],
+  actual: Map<string, TableSchema>,
+  pgSchema: string,
+  sequenceGrants?: Map<string, Map<string, Set<string>>>,
+): Operation[] {
   const ops: Operation[] = [];
 
   for (const desiredTable of desired) {
     const existing = actual.get(desiredTable.table);
     if (!existing) {
-      ops.push(...createTableOps(desiredTable, pgSchema));
+      ops.push(...createTableOps(desiredTable, pgSchema, sequenceGrants));
     } else {
-      ops.push(...alterTableOps(desiredTable, existing, pgSchema));
+      ops.push(...alterTableOps(desiredTable, existing, pgSchema, sequenceGrants));
     }
   }
 
@@ -557,7 +566,11 @@ function wrapConstraintIdempotent(constraintName: string, alterSql: string): str
   return `DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = '${constraintName}') THEN ${alterSql}; END IF; END $$`;
 }
 
-function createTableOps(table: TableSchema, pgSchema: string): Operation[] {
+function createTableOps(
+  table: TableSchema,
+  pgSchema: string,
+  sequenceGrants?: Map<string, Map<string, Set<string>>>,
+): Operation[] {
   const ops: Operation[] = [];
 
   // Prechecks (phase 0 — run before any operations)
@@ -766,7 +779,7 @@ function createTableOps(table: TableSchema, pgSchema: string): Operation[] {
       ops.push(createGrantOp(table.table, grant, pgSchema));
     }
     // Auto-generate sequence grants for serial/bigserial columns
-    ops.push(...createSequenceGrantOps(table.table, table.columns, table.grants, pgSchema));
+    ops.push(...createSequenceGrantOps(table.table, table.columns, table.grants, pgSchema, sequenceGrants));
   }
 
   // Comments (phase 14)
@@ -844,7 +857,12 @@ function createTableOps(table: TableSchema, pgSchema: string): Operation[] {
   return ops;
 }
 
-function alterTableOps(desired: TableSchema, existing: TableSchema, pgSchema: string): Operation[] {
+function alterTableOps(
+  desired: TableSchema,
+  existing: TableSchema,
+  pgSchema: string,
+  sequenceGrants?: Map<string, Map<string, Set<string>>>,
+): Operation[] {
   const ops: Operation[] = [];
 
   // Prechecks (phase 0 — run before any operations)
@@ -1001,12 +1019,11 @@ function alterTableOps(desired: TableSchema, existing: TableSchema, pgSchema: st
   ops.push(...diffGrants(desired.table, desired.grants || [], existing.grants || [], pgSchema));
 
   // Sequence grants are auto-derived from table grants for serial/bigserial
-  // columns and aren't yet introspected back, so we still emit them blindly
-  // here. They use `GRANT USAGE, SELECT` which is idempotent in Postgres
-  // (no error, no re-grant), but they do still count against the plan size.
-  // Follow-up: introspect sequence privileges and diff them here too.
+  // columns. The introspector pulls existing sequence ACLs into
+  // `sequenceGrants` (when supplied) so this diff suppresses repeats when
+  // the live ACL already carries USAGE+SELECT for the role.
   if (desired.grants) {
-    ops.push(...createSequenceGrantOps(desired.table, desired.columns, desired.grants, pgSchema));
+    ops.push(...createSequenceGrantOps(desired.table, desired.columns, desired.grants, pgSchema, sequenceGrants));
   }
 
   // Comment
@@ -2001,6 +2018,7 @@ function createSequenceGrantOps(
   columns: ColumnDef[],
   grants: GrantDef[],
   pgSchema: string,
+  existingSequenceGrants?: Map<string, Map<string, Set<string>>>,
 ): Operation[] {
   const serialCols = columns.filter((c) => SERIAL_TYPES.has(c.type.toLowerCase()));
   if (serialCols.length === 0) return [];
@@ -2021,6 +2039,10 @@ function createSequenceGrantOps(
       const key = `${seqName}.${grant.to}`;
       if (seen.has(key)) continue;
       seen.add(key);
+
+      const live = existingSequenceGrants?.get(seqName)?.get(grant.to);
+      if (live && live.has('USAGE') && live.has('SELECT')) continue;
+
       ops.push({
         type: 'grant_sequence',
         phase: 13,

--- a/test/e2e/no-churn-on-reapply.test.ts
+++ b/test/e2e/no-churn-on-reapply.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect, afterEach } from 'vitest';
-import { useTestProject, writeSchema, runMigration } from './helpers.js';
+import { useTestProject, writeSchema, runMigration, queryDb } from './helpers.js';
 import { DATABASE_URL } from './setup.js';
 import type { TestProject } from './helpers.js';
+
+let counter = 0;
+function uniqueRole(base: string): string {
+  return `${base}_${Date.now()}_${counter++}`;
+}
 
 describe('E2E: no-change reapply produces zero plan ops (#26)', () => {
   let ctx: TestProject;
@@ -99,6 +104,47 @@ checks:
     const second = await runMigration(ctx);
     expect(second.executedOperations).toEqual([]);
     expect(second.executed).toBe(0);
+  });
+
+  it('grant_sequence is suppressed when the role already has USAGE+SELECT on the sequence', async () => {
+    // Per-table sequence grants are auto-derived from each grant block with
+    // a write privilege; without an existing-state check they re-emit every
+    // plan even though the live ACL already carries USAGE+SELECT.
+    ctx = await useTestProject(DATABASE_URL);
+    const roleName = uniqueRole('seq_grant');
+    ctx.registerRole(roleName);
+    await queryDb(
+      ctx,
+      `DO $$ BEGIN
+        IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '${roleName}') THEN
+          CREATE ROLE "${roleName}";
+        END IF;
+      END $$`,
+    );
+
+    writeSchema(ctx.dir, {
+      'tables/items.yaml': `
+table: items
+columns:
+  - name: id
+    type: serial
+    primary_key: true
+  - name: name
+    type: text
+    nullable: false
+grants:
+  - to: ${roleName}
+    privileges: [INSERT, SELECT, UPDATE]
+`,
+    });
+
+    const first = await runMigration(ctx);
+    const firstSeqOps = first.executedOperations.filter((o) => o.type === 'grant_sequence');
+    expect(firstSeqOps.length).toBeGreaterThan(0);
+
+    const second = await runMigration(ctx);
+    const secondSeqOps = second.executedOperations.filter((o) => o.type === 'grant_sequence');
+    expect(secondSeqOps).toEqual([]);
   });
 
   it('seeds whose rows already exist verbatim re-apply as a no-op', async () => {


### PR DESCRIPTION
Closes #37.

Introspect `pg_class.relacl` for sequences via `aclexplode`, thread the result onto `ActualState` as a `Map<seqName, Map<role, Set<privilege>>>`, and in `createSequenceGrantOps` skip the (sequence, role) pair when the live ACL already carries both `USAGE` and `SELECT`.

Existing within-call dedupe still applies (multiple grant blocks for the same role on the same sequence still collapse to one op); this just adds the per-pair existence check against introspected state.

## Test results

- E2E regression added: a serial-PK table with a write grant emits sequence grants on first apply and zero on second.
- Full suite: 80 files / 1213 tests passing.