### PR TITLE
introspect: skip exclusion-backed indexes (#39)

### DIFF
--- a/src/introspect/index.ts
+++ b/src/introspect/index.ts
@@ -649,7 +649,7 @@ async function getIndexes(client: Client, table: string, schema: string): Promis
        AND NOT EXISTS (
          SELECT 1 FROM pg_catalog.pg_constraint con
          WHERE con.conindid = ix.indexrelid
-           AND con.contype = 'u'
+           AND con.contype IN ('u', 'x')
        )
      ORDER BY i.relname`,
     [table, schema],

--- a/test/e2e/no-churn-on-reapply.test.ts
+++ b/test/e2e/no-churn-on-reapply.test.ts
@@ -106,6 +106,46 @@ checks:
     expect(second.executed).toBe(0);
   });
 
+  it('exclusion-constraint-backed indexes are not seen as orphan on re-plan (#39)', async () => {
+    // The introspector filters constraint-backed indexes for unique
+    // constraints, but the same filter has to apply to exclusion
+    // constraints too — otherwise the GiST index that backs an EXCLUDE
+    // constraint looks orphan on every plan and gets queued for drop.
+    ctx = await useTestProject(DATABASE_URL);
+
+    writeSchema(ctx.dir, {
+      'extensions.yaml': 'extensions:\n  - btree_gist\n',
+      'tables/bookings.yaml': `
+table: bookings
+columns:
+  - name: id
+    type: integer
+    primary_key: true
+  - name: room_id
+    type: integer
+    nullable: false
+  - name: during
+    type: int4range
+    nullable: false
+exclusion_constraints:
+  - name: bookings_no_overlap
+    using: gist
+    elements:
+      - column: room_id
+        operator: '='
+      - column: during
+        operator: '&&'
+`,
+    });
+
+    const first = await runMigration(ctx);
+    expect(first.executed).toBeGreaterThan(0);
+
+    const second = await runMigration(ctx);
+    expect(second.executedOperations).toEqual([]);
+    expect(second.executed).toBe(0);
+  });
+
   it('grant_sequence is suppressed when the role already has USAGE+SELECT on the sequence', async () => {
     // Per-table sequence grants are auto-derived from each grant block with
     // a write privilege; without an existing-state check they re-emit every


### PR DESCRIPTION
Closes #39. Single-line filter broadening with e2e regression. Suite: 80 files / 1213 tests passing.