### PR TITLE
introspect: format_type for column type (#40)

### DIFF
--- a/src/__tests__/numeric-precision-introspect.test.ts
+++ b/src/__tests__/numeric-precision-introspect.test.ts
@@ -107,6 +107,10 @@ columns:
   });
 
   it('introspects varchar(N) and char(N) columns correctly', async () => {
+    // Introspection uses format_type(atttypid, atttypmod) so the type
+    // string matches PG's canonical renderer — `character varying(10)`,
+    // not the `varchar(10)` shorthand. The planner's normalizeTypeName
+    // collapses the alias on diff so YAML can keep using either form.
     await client.query(`
       CREATE TABLE ${TEST_SCHEMA}.strings (
         id serial PRIMARY KEY,
@@ -121,8 +125,8 @@ columns:
     const fixedCol = table.columns.find((c) => c.name === 'fixed');
     const unlimitedCol = table.columns.find((c) => c.name === 'unlimited');
 
-    expect(codeCol!.type).toBe('varchar(10)');
-    expect(fixedCol!.type).toBe('char(5)');
-    expect(unlimitedCol!.type).toBe('varchar');
+    expect(codeCol!.type).toBe('character varying(10)');
+    expect(fixedCol!.type).toBe('character(5)');
+    expect(unlimitedCol!.type).toBe('character varying');
   });
 });

--- a/src/introspect/index.ts
+++ b/src/introspect/index.ts
@@ -523,89 +523,57 @@ async function getCompositePrimaryKey(
 }
 
 async function getColumns(client: Client, table: string, schema: string): Promise<ColumnDef[]> {
+  // Type comes from format_type(atttypid, atttypmod) on pg_attribute —
+  // PG's own canonical renderer. It handles every parametrised type
+  // uniformly: numeric(p,s), varchar(n), timestamptz, geography(Polygon,
+  // 4326), int4range, etc. information_schema.columns drops the typmod
+  // for PostGIS types, so anything geography/geometry-shaped gets
+  // perpetual alter_column drift if the YAML carries a typmod.
   const result = await client.query(
     `SELECT
-       c.column_name AS name,
-       c.udt_name AS udt_type,
-       c.character_maximum_length AS max_length,
-       c.numeric_precision AS num_precision,
-       c.numeric_scale AS num_scale,
-       c.is_nullable = 'YES' AS nullable,
-       c.column_default AS "default",
-       c.is_generated = 'ALWAYS' AS is_generated,
-       c.generation_expression,
-       col_description(
-         (SELECT oid FROM pg_catalog.pg_class WHERE relname = $1 AND relnamespace = (SELECT oid FROM pg_catalog.pg_namespace WHERE nspname = $2)),
-         c.ordinal_position
-       ) AS comment,
+       a.attname AS name,
+       format_type(a.atttypid, a.atttypmod) AS type,
+       NOT a.attnotnull AS nullable,
+       pg_get_expr(d.adbin, d.adrelid) AS "default",
+       a.attgenerated <> '' AS is_generated,
+       CASE WHEN a.attgenerated <> '' THEN pg_get_expr(d.adbin, d.adrelid) END AS generation_expression,
+       col_description(c.oid, a.attnum) AS comment,
        EXISTS (
          SELECT 1 FROM pg_catalog.pg_constraint con
-         JOIN pg_catalog.pg_class cls ON cls.oid = con.conrelid
-         JOIN pg_catalog.pg_namespace ns ON ns.oid = cls.relnamespace
          WHERE con.contype = 'p'
-           AND cls.relname = $1
-           AND ns.nspname = $2
-           AND c.ordinal_position = ANY(con.conkey)
+           AND con.conrelid = c.oid
+           AND a.attnum = ANY(con.conkey)
        ) AS is_primary_key
-     FROM information_schema.columns c
-     WHERE c.table_schema = $2
-       AND c.table_name = $1
-     ORDER BY c.ordinal_position`,
+     FROM pg_catalog.pg_class c
+     JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+     JOIN pg_catalog.pg_attribute a ON a.attrelid = c.oid AND a.attnum > 0 AND NOT a.attisdropped
+     LEFT JOIN pg_catalog.pg_attrdef d ON d.adrelid = a.attrelid AND d.adnum = a.attnum
+     WHERE c.relname = $1
+       AND n.nspname = $2
+     ORDER BY a.attnum`,
     [table, schema],
   );
 
   return result.rows.map((r: Record<string, unknown>) => {
     const col: ColumnDef = {
       name: r.name as string,
-      type: normalizeType(
-        r.udt_type as string,
-        r.max_length as number | null,
-        r.num_precision as number | null,
-        r.num_scale as number | null,
-      ),
+      type: r.type as string,
       nullable: r.nullable as boolean,
     };
 
     if (r.is_primary_key) col.primary_key = true;
-    if (r.default !== null && r.default !== undefined) col.default = r.default as string;
+    // pg_attrdef carries both the SET DEFAULT expression and the
+    // generated-column expression. Only treat it as a default when the
+    // column isn't generated — otherwise the planner would chase it as a
+    // mismatched DEFAULT.
+    if (!r.is_generated && r.default !== null && r.default !== undefined) {
+      col.default = r.default as string;
+    }
     if (r.comment) col.comment = r.comment as string;
     if (r.is_generated && r.generation_expression) col.generated = r.generation_expression as string;
 
     return col;
   });
-}
-
-function normalizeType(
-  udtType: string,
-  maxLength: number | null,
-  numPrecision: number | null,
-  numScale: number | null,
-): string {
-  // Map common udt_name values to user-friendly types
-  const typeMap: Record<string, string> = {
-    int4: 'integer',
-    int8: 'bigint',
-    int2: 'smallint',
-    float4: 'real',
-    float8: 'double precision',
-    bool: 'boolean',
-    timestamptz: 'timestamptz',
-    timestamp: 'timestamp',
-    varchar: maxLength ? `varchar(${maxLength})` : 'varchar',
-    bpchar: maxLength ? `char(${maxLength})` : 'char',
-    numeric: numPrecision != null ? `numeric(${numPrecision},${numScale ?? 0})` : 'numeric',
-  };
-
-  if (typeMap[udtType]) return typeMap[udtType];
-
-  // For arrays, information_schema shows ARRAY but udt_name starts with _
-  if (udtType.startsWith('_')) {
-    const baseType = udtType.slice(1);
-    const mapped = typeMap[baseType] || baseType;
-    return `${mapped}[]`;
-  }
-
-  return udtType;
 }
 
 async function getIndexes(client: Client, table: string, schema: string): Promise<IndexDef[]> {

--- a/src/planner/index.ts
+++ b/src/planner/index.ts
@@ -2273,7 +2273,16 @@ function escapeQuote(s: string): string {
 }
 
 function normalizeTypeName(t: string): string {
-  const lower = t.toLowerCase().trim();
+  // Strip whitespace adjacent to parens/commas so `numeric(10, 2)` matches
+  // `numeric(10,2)` (PG's format_type renders without the inner space).
+  const stripped = t
+    .toLowerCase()
+    .trim()
+    .replace(/\s*([(),])\s*/g, '$1');
+  // Split into base name and optional parenthesised args.
+  const match = stripped.match(/^([^()]+?)(\(.+\))?$/);
+  const base = match ? match[1].trim() : stripped;
+  const params = match && match[2] ? match[2] : '';
   const aliases: Record<string, string> = {
     int: 'integer',
     int4: 'integer',
@@ -2284,8 +2293,21 @@ function normalizeTypeName(t: string): string {
     bool: 'boolean',
     serial: 'integer',
     bigserial: 'bigint',
+    smallserial: 'smallint',
+    varchar: 'character varying',
+    'character varying': 'character varying',
+    char: 'character',
+    bpchar: 'character',
+    character: 'character',
+    timestamptz: 'timestamp with time zone',
+    'timestamp with time zone': 'timestamp with time zone',
+    'timestamp without time zone': 'timestamp without time zone',
+    timetz: 'time with time zone',
+    'time with time zone': 'time with time zone',
+    'time without time zone': 'time without time zone',
   };
-  return aliases[lower] || lower;
+  const canonicalBase = aliases[base] || base;
+  return `${canonicalBase}${params}`;
 }
 
 function normalizeWhitespace(s: string): string {

--- a/test/e2e/no-churn-on-reapply.test.ts
+++ b/test/e2e/no-churn-on-reapply.test.ts
@@ -146,6 +146,41 @@ exclusion_constraints:
     expect(second.executed).toBe(0);
   });
 
+  it('column type with whitespace inside parameters re-applies as a no-op (#40)', async () => {
+    // YAML may declare `numeric(10, 2)` or `varchar(50)`; PG's format_type
+    // canonicalises both with no inner whitespace, mixed-case parameters,
+    // and friendly aliases (varchar → character varying). Same shape
+    // covers PostGIS geography(Polygon, 4326) which information_schema
+    // strips of its typmod entirely.
+    ctx = await useTestProject(DATABASE_URL);
+
+    writeSchema(ctx.dir, {
+      'tables/orders.yaml': `
+table: orders
+columns:
+  - name: id
+    type: integer
+    primary_key: true
+  - name: total
+    type: 'numeric(10, 2)'
+    nullable: false
+  - name: code
+    type: 'varchar(50)'
+    nullable: false
+  - name: created_at
+    type: timestamptz
+    nullable: false
+`,
+    });
+
+    const first = await runMigration(ctx);
+    expect(first.executed).toBeGreaterThan(0);
+
+    const second = await runMigration(ctx);
+    expect(second.executedOperations).toEqual([]);
+    expect(second.executed).toBe(0);
+  });
+
   it('grant_sequence is suppressed when the role already has USAGE+SELECT on the sequence', async () => {
     // Per-table sequence grants are auto-derived from each grant block with
     // a write privilege; without an existing-state check they re-emit every


### PR DESCRIPTION
Closes #40. Reads column type via pg_attribute + format_type so PostGIS typmods (and other parametrised types) round-trip cleanly. normalizeTypeName gains aliases for character varying / timestamptz / timetz / char so YAML shorthand still works.

Suite: 80 files / 1214 tests passing.