### PR TITLE
planner: round-trip column DEFAULT expressions (#41)

### DIFF
--- a/src/cli/pipeline.ts
+++ b/src/cli/pipeline.ts
@@ -26,6 +26,7 @@ import {
   normalizePolicyExpressions,
   normalizeCheckExpressions,
   normalizeIndexWhereClauses,
+  normalizeColumnDefaults,
 } from '../planner/normalize-expression.js';
 import { filterUnchangedSeeds } from '../planner/filter-seeds.js';
 import { execute } from '../executor/index.js';
@@ -90,6 +91,7 @@ export async function runPipeline(
       await normalizePolicyExpressions(normClient, desired.tables);
       await normalizeCheckExpressions(normClient, desired.tables);
       await normalizeIndexWhereClauses(normClient, desired.tables);
+      await normalizeColumnDefaults(normClient, desired.tables);
       await filterUnchangedSeeds(normClient, desired.tables, config.pgSchema);
     } finally {
       normClient.release();

--- a/src/planner/normalize-expression.ts
+++ b/src/planner/normalize-expression.ts
@@ -169,6 +169,72 @@ export async function normalizeIndexWhereClauses(client: PoolClient, tables: Tab
   }
 }
 
+/**
+ * Normalize all column DEFAULT expressions in the given tables by
+ * round-tripping through PostgreSQL. PG canonicalises functional defaults
+ * — `CURRENT_TIMESTAMP + INTERVAL '7 days'` becomes
+ * `(CURRENT_TIMESTAMP + '7 days'::interval)`, regex literals get `::text`
+ * casts, etc. — so the diff has to compare the YAML text against PG's
+ * post-rewrite form for ALTER COLUMN SET DEFAULT to settle on a re-plan.
+ *
+ * Bare-literal defaults (`true`, `'foo'`, `0`) round-trip unchanged in
+ * most cases but go through the same path so the behaviour is uniform.
+ */
+export async function normalizeColumnDefaults(client: PoolClient, tables: TableSchema[]): Promise<void> {
+  const tablesWithDefaults = tables.filter(
+    (t) => t.table && t.columns.some((c) => c.default !== undefined && c.default !== null),
+  );
+  if (tablesWithDefaults.length === 0) return;
+
+  await client.query('BEGIN');
+  try {
+    for (const table of tablesWithDefaults) {
+      for (const col of table.columns) {
+        if (col.default === undefined || col.default === null) continue;
+        col.default = await normalizeColumnDefault(client, table, col.name, col.type, col.default);
+      }
+    }
+  } finally {
+    await client.query('ROLLBACK');
+  }
+}
+
+async function normalizeColumnDefault(
+  client: PoolClient,
+  table: TableSchema,
+  columnName: string,
+  columnType: string,
+  expression: string,
+): Promise<string> {
+  // See normalizeExpression for the temp-table-shadows-real-table rationale.
+  const tempTable = table.table;
+
+  await client.query('SAVEPOINT normalize_default');
+  try {
+    await client.query(
+      `CREATE TEMP TABLE "${tempTable}" ("${columnName}" ${mapColumnType(columnType)} DEFAULT ${expression})`,
+    );
+
+    const result = await client.query(
+      `SELECT pg_get_expr(ad.adbin, ad.adrelid) AS expr
+       FROM pg_catalog.pg_attrdef ad
+       JOIN pg_catalog.pg_class cls ON cls.oid = ad.adrelid
+       JOIN pg_catalog.pg_attribute a ON a.attrelid = ad.adrelid AND a.attnum = ad.adnum
+       WHERE cls.relname = $1
+         AND a.attname = $2
+         AND cls.relnamespace = pg_my_temp_schema()`,
+      [tempTable, columnName],
+    );
+
+    const expr = result.rows[0]?.expr as string | undefined;
+    await client.query('ROLLBACK TO normalize_default');
+    return expr ?? expression;
+  } catch {
+    await client.query('ROLLBACK TO normalize_default').catch(() => {});
+    return expression;
+  }
+}
+
 async function normalizeIndexWhere(client: PoolClient, table: TableSchema, where: string): Promise<string> {
   // See normalizeExpression for the temp-table-shadows-real-table rationale.
   const tempTable = table.table;

--- a/test/e2e/no-churn-on-reapply.test.ts
+++ b/test/e2e/no-churn-on-reapply.test.ts
@@ -181,6 +181,43 @@ columns:
     expect(second.executed).toBe(0);
   });
 
+  it('column DEFAULT with functional expression re-applies as a no-op (#41)', async () => {
+    // Functional defaults like CURRENT_TIMESTAMP + INTERVAL '7 days'
+    // get rewritten by PG (parens, casts, normalised whitespace), so a
+    // literal string compare against pg_attrdef would re-fire the alter
+    // every plan. The default round-trip pass settles them.
+    ctx = await useTestProject(DATABASE_URL);
+
+    writeSchema(ctx.dir, {
+      'tables/sessions.yaml': `
+table: sessions
+columns:
+  - name: id
+    type: integer
+    primary_key: true
+  - name: created_at
+    type: timestamptz
+    nullable: false
+    default: CURRENT_TIMESTAMP
+  - name: expires_at
+    type: timestamptz
+    nullable: false
+    default: CURRENT_TIMESTAMP + INTERVAL '7 days'
+  - name: active
+    type: boolean
+    nullable: false
+    default: 'true'
+`,
+    });
+
+    const first = await runMigration(ctx);
+    expect(first.executed).toBeGreaterThan(0);
+
+    const second = await runMigration(ctx);
+    expect(second.executedOperations).toEqual([]);
+    expect(second.executed).toBe(0);
+  });
+
   it('grant_sequence is suppressed when the role already has USAGE+SELECT on the sequence', async () => {
     // Per-table sequence grants are auto-derived from each grant block with
     // a write privilege; without an existing-state check they re-emit every


### PR DESCRIPTION
Closes #41. New normalizeColumnDefaults pass alongside the existing policy/check/where normalisers. Functional defaults (CURRENT_TIMESTAMP + INTERVAL …) now settle on re-plan instead of re-firing alter_column.

Suite: 80 files / 1214 tests passing.