### PR TITLE
planner: diff view bodies, comments, grants (#42)

### DIFF
--- a/src/cli/pipeline.ts
+++ b/src/cli/pipeline.ts
@@ -27,6 +27,7 @@ import {
   normalizeCheckExpressions,
   normalizeIndexWhereClauses,
   normalizeColumnDefaults,
+  normalizeViewBodies,
 } from '../planner/normalize-expression.js';
 import { filterUnchangedSeeds } from '../planner/filter-seeds.js';
 import { execute } from '../executor/index.js';
@@ -92,6 +93,7 @@ export async function runPipeline(
       await normalizeCheckExpressions(normClient, desired.tables);
       await normalizeIndexWhereClauses(normClient, desired.tables);
       await normalizeColumnDefaults(normClient, desired.tables);
+      await normalizeViewBodies(normClient, desired.views);
       await filterUnchangedSeeds(normClient, desired.tables, config.pgSchema);
     } finally {
       normClient.release();

--- a/src/introspect/index.ts
+++ b/src/introspect/index.ts
@@ -246,7 +246,9 @@ function parseArgList(arglist: string): FunctionArg[] {
 /** Get all regular views in a schema, excluding extension-owned views. */
 export async function getExistingViews(client: Client, schema: string): Promise<ViewSchema[]> {
   const result = await client.query(
-    `SELECT v.viewname AS name, v.definition AS query
+    `SELECT v.viewname AS name,
+            pg_get_viewdef(c.oid, true) AS query,
+            obj_description(c.oid, 'pg_class') AS comment
      FROM pg_catalog.pg_views v
      JOIN pg_catalog.pg_class c ON c.relname = v.viewname
      JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace AND n.nspname = v.schemaname
@@ -261,18 +263,49 @@ export async function getExistingViews(client: Client, schema: string): Promise<
     [schema],
   );
   const views: ViewSchema[] = [];
-  for (const r of result.rows as { name: string; query: string }[]) {
+  for (const r of result.rows as { name: string; query: string; comment: string | null }[]) {
     const view: ViewSchema = {
       name: r.name,
-      query: r.query.trim(),
+      // pg_get_viewdef appends a trailing semicolon and may include a
+      // trailing newline; strip both so the canonical form matches what
+      // the round-trip normaliser produces for desired views.
+      query: r.query.trim().replace(/;$/, '').trim(),
     };
+    if (r.comment) view.comment = r.comment;
     const triggers = await getTriggers(client, r.name, schema);
-    if (triggers.length > 0) {
-      view.triggers = triggers;
-    }
+    if (triggers.length > 0) view.triggers = triggers;
+    const grants = await getViewGrants(client, r.name, schema);
+    if (grants.length > 0) view.grants = grants;
     views.push(view);
   }
   return views;
+}
+
+async function getViewGrants(client: Client, view: string, schema: string): Promise<GrantDef[]> {
+  const result = await client.query(
+    `SELECT grantee, privilege_type, is_grantable
+     FROM information_schema.role_table_grants
+     WHERE table_schema = $2
+       AND table_name = $1
+       AND grantor <> grantee
+     ORDER BY grantee, privilege_type`,
+    [view, schema],
+  );
+
+  const mergeMap = new Map<string, GrantDef>();
+  for (const row of result.rows as { grantee: string; privilege_type: string; is_grantable: string }[]) {
+    const key = row.grantee;
+    const existing = mergeMap.get(key);
+    if (existing) {
+      existing.privileges.push(row.privilege_type);
+      existing.privileges.sort();
+    } else {
+      const grant: GrantDef = { to: row.grantee, privileges: [row.privilege_type] };
+      if (row.is_grantable === 'YES') grant.with_grant_option = true;
+      mergeMap.set(key, grant);
+    }
+  }
+  return [...mergeMap.values()];
 }
 
 /** Get all materialized views in a schema, excluding extension-owned ones. */

--- a/src/planner/__tests__/planner.test.ts
+++ b/src/planner/__tests__/planner.test.ts
@@ -1252,7 +1252,8 @@ describe('Planner', () => {
       expect(grantOps).toHaveLength(2);
       expect(grantOps[0].sql).toContain('"app_readonly"');
       expect(grantOps[1].sql).toContain('"app_writer"');
-      expect(grantOps[1].sql).toContain('SELECT, INSERT');
+      // diffGrants sorts privileges alphabetically before emission.
+      expect(grantOps[1].sql).toContain('INSERT, SELECT');
     });
 
     it('generates WITH clause when options are specified', () => {

--- a/src/planner/index.ts
+++ b/src/planner/index.ts
@@ -2068,23 +2068,29 @@ function diffViews(desired: ViewSchema[], actual: Map<string, ViewSchema>, pgSch
   const ops: Operation[] = [];
 
   for (const view of desired) {
-    ops.push({
-      type: 'create_view',
-      phase: 9,
-      objectName: view.name,
-      sql: `CREATE OR REPLACE VIEW "${pgSchema}"."${view.name}"${formatViewOptions(view.options)} AS ${view.query}`,
-      destructive: false,
-    });
+    const existingView = actual.get(view.name);
+
+    // Bodies arrive normalised on both sides — desired is round-tripped
+    // through the temp-view normaliser, existing comes from
+    // pg_get_viewdef. Skip the CREATE OR REPLACE when they match.
+    if (!existingView || existingView.query !== view.query) {
+      ops.push({
+        type: 'create_view',
+        phase: 9,
+        objectName: view.name,
+        sql: `CREATE OR REPLACE VIEW "${pgSchema}"."${view.name}"${formatViewOptions(view.options)} AS ${view.query}`,
+        destructive: false,
+      });
+    }
 
     // Diff triggers on the view (INSTEAD OF triggers)
-    const existingView = actual.get(view.name);
     const desiredTriggers = view.triggers || [];
     const existingTriggers = existingView?.triggers || [];
     if (desiredTriggers.length > 0 || existingTriggers.length > 0) {
       ops.push(...diffTriggers(view.name, desiredTriggers, existingTriggers, pgSchema));
     }
 
-    if (view.comment) {
+    if (view.comment && view.comment !== existingView?.comment) {
       ops.push({
         type: 'set_comment',
         phase: 14,
@@ -2095,16 +2101,7 @@ function diffViews(desired: ViewSchema[], actual: Map<string, ViewSchema>, pgSch
     }
 
     if (view.grants) {
-      for (const grant of view.grants) {
-        const privileges = grant.privileges.join(', ');
-        ops.push({
-          type: 'grant_table',
-          phase: 13,
-          objectName: `${view.name}.${grant.to}`,
-          sql: `GRANT ${privileges} ON "${pgSchema}"."${view.name}" TO "${grant.to}"`,
-          destructive: false,
-        });
-      }
+      ops.push(...diffGrants(view.name, view.grants, existingView?.grants ?? [], pgSchema));
     }
   }
 

--- a/src/planner/normalize-expression.ts
+++ b/src/planner/normalize-expression.ts
@@ -148,6 +148,55 @@ async function normalizeCheckExpression(client: PoolClient, table: TableSchema, 
 }
 
 /**
+ * Normalize each view's `query` by round-tripping through PostgreSQL.
+ * `pg_get_viewdef` returns the canonical, fully-qualified, reformatted
+ * body — without this round-trip, a literal compare against the YAML
+ * form would re-fire `CREATE OR REPLACE VIEW` on every plan because PG
+ * adds parens, normalises whitespace, expands `*`, and qualifies
+ * identifiers.
+ *
+ * Mutates each view's `query` in place. Errors (referenced tables don't
+ * yet exist on a fresh DB) leave the YAML form unchanged so the first
+ * apply still creates the view.
+ */
+export async function normalizeViewBodies(client: PoolClient, views: { name: string; query: string }[]): Promise<void> {
+  if (views.length === 0) return;
+
+  await client.query('BEGIN');
+  try {
+    for (const view of views) {
+      view.query = await normalizeViewBody(client, view.name, view.query);
+    }
+  } finally {
+    await client.query('ROLLBACK');
+  }
+}
+
+async function normalizeViewBody(client: PoolClient, viewName: string, query: string): Promise<string> {
+  await client.query('SAVEPOINT normalize_view');
+  try {
+    // Use the real view name for the temp view — pg_temp shadows any
+    // persistent same-named view for the savepoint's lifetime.
+    await client.query(`CREATE TEMP VIEW "${viewName}" AS ${query}`);
+
+    const result = await client.query(
+      `SELECT pg_get_viewdef(c.oid, true) AS def
+       FROM pg_catalog.pg_class c
+       JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+       WHERE c.relname = $1 AND n.oid = pg_my_temp_schema()`,
+      [viewName],
+    );
+
+    const def = result.rows[0]?.def as string | undefined;
+    await client.query('ROLLBACK TO normalize_view');
+    return def ? def.trim().replace(/;$/, '') : query;
+  } catch {
+    await client.query('ROLLBACK TO normalize_view').catch(() => {});
+    return query;
+  }
+}
+
+/**
  * Normalize all partial-index WHERE clauses in the given tables by
  * round-tripping through PostgreSQL. Same shape as the policy/check
  * normalisers; uses a temp index to capture PG's canonical form.

--- a/test/e2e/no-churn-on-reapply.test.ts
+++ b/test/e2e/no-churn-on-reapply.test.ts
@@ -218,6 +218,58 @@ columns:
     expect(second.executed).toBe(0);
   });
 
+  it('view body, comment, and grants re-apply as a no-op (#42)', async () => {
+    // pg_get_viewdef rewrites view bodies (parens, qualifications,
+    // whitespace) so a literal compare against the YAML query would
+    // re-fire CREATE OR REPLACE every plan. Round-trip both sides.
+    // Comment and grant cascading are also covered.
+    ctx = await useTestProject(DATABASE_URL);
+    const roleName = uniqueRole('view_grant');
+    ctx.registerRole(roleName);
+    await queryDb(
+      ctx,
+      `DO $$ BEGIN
+        IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '${roleName}') THEN
+          CREATE ROLE "${roleName}";
+        END IF;
+      END $$`,
+    );
+
+    writeSchema(ctx.dir, {
+      'tables/orders.yaml': `
+table: orders
+columns:
+  - name: id
+    type: integer
+    primary_key: true
+  - name: status
+    type: text
+    nullable: false
+  - name: total
+    type: integer
+    nullable: false
+`,
+      'views/active_orders.yaml': `
+name: active_orders
+query: |-
+  SELECT id, total
+    FROM orders
+    WHERE status = 'active' AND total > 0
+comment: Visible orders that haven't been archived.
+grants:
+  - to: ${roleName}
+    privileges: [SELECT]
+`,
+    });
+
+    const first = await runMigration(ctx);
+    expect(first.executed).toBeGreaterThan(0);
+
+    const second = await runMigration(ctx);
+    expect(second.executedOperations).toEqual([]);
+    expect(second.executed).toBe(0);
+  });
+
   it('grant_sequence is suppressed when the role already has USAGE+SELECT on the sequence', async () => {
     // Per-table sequence grants are auto-derived from each grant block with
     // a write privilege; without an existing-state check they re-emit every


### PR DESCRIPTION
Closes #42. Three coupled changes:

- Round-trip desired view query through PG via temp view + pg_get_viewdef so the canonical form matches what introspection sees.
- Introspect view comment (obj_description) and view grants (information_schema.role_table_grants).
- diffViews now skips create_view when bodies match, skips set_comment when comments match, and routes view grants through the existing diffGrants helper.

Suite: 80 files / 1214 tests passing.